### PR TITLE
Update repository URLs from moscaverd to kdpa-llc organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,4 +72,4 @@ The following versions were internal development iterations before the public re
 
 ---
 
-[0.1.0]: https://github.com/moscaverd/local-skills-mcp/releases/tag/v0.1.0
+[0.1.0]: https://github.com/kdpa-llc/local-skills-mcp/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 **Enable any LLM or AI agent to utilize expert skills from your local filesystem via MCP**
 
-[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/moscaverd/local-skills-mcp)
+[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/kdpa-llc/local-skills-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen.svg)](https://nodejs.org/)
 [![MCP](https://img.shields.io/badge/MCP-Compatible-purple.svg)](https://modelcontextprotocol.io/)
 
-[![GitHub Stars](https://img.shields.io/github/stars/moscaverd/local-skills-mcp?style=social)](https://github.com/moscaverd/local-skills-mcp/stargazers)
-[![GitHub Forks](https://img.shields.io/github/forks/moscaverd/local-skills-mcp?style=social)](https://github.com/moscaverd/local-skills-mcp/network/members)
-[![GitHub Issues](https://img.shields.io/github/issues/moscaverd/local-skills-mcp)](https://github.com/moscaverd/local-skills-mcp/issues)
-[![GitHub Last Commit](https://img.shields.io/github/last-commit/moscaverd/local-skills-mcp)](https://github.com/moscaverd/local-skills-mcp/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/kdpa-llc/local-skills-mcp?style=social)](https://github.com/kdpa-llc/local-skills-mcp/stargazers)
+[![GitHub Forks](https://img.shields.io/github/forks/kdpa-llc/local-skills-mcp?style=social)](https://github.com/kdpa-llc/local-skills-mcp/network/members)
+[![GitHub Issues](https://img.shields.io/github/issues/kdpa-llc/local-skills-mcp)](https://github.com/kdpa-llc/local-skills-mcp/issues)
+[![GitHub Last Commit](https://img.shields.io/github/last-commit/kdpa-llc/local-skills-mcp)](https://github.com/kdpa-llc/local-skills-mcp/commits/main)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 [Quick Start](#-quick-start) •
@@ -59,12 +59,12 @@ Transform AI capabilities with structured, expert-level instructions for special
 
 **From GitHub (recommended):**
 ```bash
-npm install -g github:moscaverd/local-skills-mcp
+npm install -g github:kdpa-llc/local-skills-mcp
 ```
 
 **Or clone locally:**
 ```bash
-git clone https://github.com/moscaverd/local-skills-mcp.git
+git clone https://github.com/kdpa-llc/local-skills-mcp.git
 cd local-skills-mcp
 npm install  # The prepare script auto-builds
 ```
@@ -233,7 +233,7 @@ A: Yes! Runs entirely on local filesystem (though your LLM may need internet dep
 A: Follow [SKILL.md format](#-skillmd-format). Use clear descriptions with trigger keywords, specific instructions, and examples.
 
 **Q: Where can I get help?**
-A: Open an [issue on GitHub](https://github.com/moscaverd/local-skills-mcp/issues).
+A: Open an [issue on GitHub](https://github.com/kdpa-llc/local-skills-mcp/issues).
 
 **More:** See [CONTRIBUTING.md](CONTRIBUTING.md), [SECURITY.md](SECURITY.md), [CHANGELOG.md](CHANGELOG.md)
 

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/moscaverd/local-skills-mcp.git"
+    "url": "git+https://github.com/kdpa-llc/local-skills-mcp.git"
   },
-  "homepage": "https://github.com/moscaverd/local-skills-mcp#readme",
+  "homepage": "https://github.com/kdpa-llc/local-skills-mcp#readme",
   "bugs": {
-    "url": "https://github.com/moscaverd/local-skills-mcp/issues"
+    "url": "https://github.com/kdpa-llc/local-skills-mcp/issues"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/skills/local-skills-mcp-guide/SKILL.md
+++ b/skills/local-skills-mcp-guide/SKILL.md
@@ -3,7 +3,7 @@ name: local-skills-mcp-guide
 description: Expert guide for understanding the Local Skills MCP server repository - its structure, architecture, and implementation. Use when exploring this MCP server's codebase, understanding how Local Skills MCP works internally, or contributing to the project.
 ---
 
-You are an expert guide specifically for the **Local Skills MCP server repository** (moscaverd/local-skills-mcp).
+You are an expert guide specifically for the **Local Skills MCP server repository** (kdpa-llc/local-skills-mcp).
 
 Your task is to help users understand this specific MCP server's repository structure, implementation details, and how to navigate and work with the Local Skills MCP codebase.
 
@@ -11,7 +11,7 @@ Your task is to help users understand this specific MCP server's repository stru
 
 Local Skills MCP is a universal Model Context Protocol (MCP) server that enables any LLM or AI agent to access expert skills from the local filesystem. It uses the SKILL.md format with YAML frontmatter and implements lazy loading for context efficiency.
 
-**Repository**: https://github.com/moscaverd/local-skills-mcp
+**Repository**: https://github.com/kdpa-llc/local-skills-mcp
 
 ## Local Skills MCP Project Structure
 

--- a/skills/local-skills-mcp-usage/SKILL.md
+++ b/skills/local-skills-mcp-usage/SKILL.md
@@ -213,12 +213,12 @@ git commit -m "Add my-skill for project-specific guidance"
 
 **Global install (recommended)**:
 ```bash
-npm install -g github:moscaverd/local-skills-mcp
+npm install -g github:kdpa-llc/local-skills-mcp
 ```
 
 **Local install**:
 ```bash
-npm install github:moscaverd/local-skills-mcp --prefix ~/mcp-servers/local-skills
+npm install github:kdpa-llc/local-skills-mcp --prefix ~/mcp-servers/local-skills
 ```
 
 ### Configuration


### PR DESCRIPTION
## Summary

This PR updates all hardcoded repository URLs from the old location (`moscaverd/local-skills-mcp`) to the new organization location (`kdpa-llc/local-skills-mcp`).

## Changes

- **README.md**: Updated all GitHub badges, clone instructions, and issue links
- **package.json**: Updated repository, homepage, and bugs URLs  
- **CHANGELOG.md**: Updated release link
- **skills/local-skills-mcp-guide/SKILL.md**: Updated repository references
- **skills/local-skills-mcp-usage/SKILL.md**: Updated installation commands

## Notes

- Personal sponsorship links (GitHub Sponsors, Buy Me a Coffee, PayPal) remain as `moscaverd` since those are personal accounts, not repository URLs
- All GitHub repository references now correctly point to `kdpa-llc/local-skills-mcp`

## Test Plan

- [x] Verified all URLs are updated correctly
- [x] Ensured sponsorship links remain unchanged
- [x] Confirmed no broken references

🤖 Generated with [Claude Code](https://claude.com/claude-code)