### PR TITLE
Claude/enable full hot reload 011 c us6 eneh bty xhds km xyqv

### DIFF
--- a/skills/local-skills-mcp-usage/SKILL.md
+++ b/skills/local-skills-mcp-usage/SKILL.md
@@ -331,18 +331,18 @@ Claude will automatically invoke the appropriate skill via the `get_skill` tool.
 **After modifying a skill**:
 
 1. Save changes to SKILL.md
-2. For new skills: **Refresh the tool list** - they appear immediately
-3. For content changes: **Restart MCP server** - skill content is cached and persists until restart
+2. Changes take effect immediately - no restart needed!
+3. Next time the skill is loaded, it will read the updated content from disk
 
 **How Hot Reload Works**:
 
 - **New skills**: Discovered immediately - no restart needed!
   - Skill list refreshes every time tools are requested
   - Add a new skill directory → refresh tool list → skill appears
-- **Modified skills**: Require restart - content is cached
-  - Skill content is cached after first load
-  - Cache persists until server restart
-  - Changing skill content requires restarting the MCP server
+- **Modified skills**: Also work immediately - no restart needed!
+  - Skills are always loaded fresh from disk
+  - Edit a SKILL.md → next `get_skill` call reads the new content
+  - Full hot reload support for all changes
 
 ## Practical Examples
 

--- a/src/skill-loader.test.ts
+++ b/src/skill-loader.test.ts
@@ -353,7 +353,7 @@ Content`
   });
 
   describe("loadSkill", () => {
-    it("should load and cache a skill", async () => {
+    it("should load a skill fresh from disk each time", async () => {
       const skillPath = path.join(tempDir, "test-skill");
       await fs.mkdir(skillPath, { recursive: true });
       await fs.writeFile(
@@ -377,9 +377,10 @@ Skill content here`
       expect(skill1.path).toBe(skillPath);
       expect(skill1.source).toBe(tempDir);
 
-      // Second load should use cache
+      // Second load should create a new object with same data (no caching)
       const skill2 = await skillLoader.loadSkill("test-skill");
-      expect(skill2).toBe(skill1); // Same object reference
+      expect(skill2).toStrictEqual(skill1); // Same data, different object
+      expect(skill2).not.toBe(skill1); // Different object references
     });
 
     it("should throw error for non-existent skill", async () => {


### PR DESCRIPTION
# Enable Full Hot Reload by Removing Skill Content Cache

## Summary

This PR implements full hot reload for all skill changes by removing the skill content cache from the MCP server. Previously, only new skills were hot-reloaded (via registry refresh on each tool list request), but skill content was cached and required a server restart to update. Now all changes—new skills, content edits, and description changes—apply immediately without any restart.

## What Changed

### Code Changes:

* `src/skill-loader.ts`:
  * Removed `skillCache` property that was storing loaded skills
  * Updated `loadSkill()` to always read fresh from disk instead of checking cache
  * Updated class and method documentation to reflect hot reload behavior

* `src/skill-loader.test.ts`:
  * Renamed test from "should load and cache a skill" to "should load a skill fresh from disk each time"
  * Fixed test expectations: now verifies new objects are created on each load (not cached references)

### Documentation Updates:

* `skills/local-skills-mcp-usage/SKILL.md`:
  * Updated "Skill Lifecycle" section to document full hot reload
  * Removed incorrect instructions about restarting for content changes

* `skills/skill-refresh-helper/SKILL.md`:
  * Updated to reflect zero caching behavior
  * Changed examples to show content changes apply immediately

## Why This Change

**Problem:**
* Users had to restart the MCP server every time they edited skill content
* This created a poor developer experience for skill iteration
* Documentation was misleading about hot reload capabilities

**Solution:**
* Remove the cache to enable true hot reload for all changes
* Skills are now loaded fresh from disk on every `get_skill` call
* Immediate feedback loop for skill development

## How Hot Reload Works Now

**Registry (Skill Discovery):**
* Cleared and rebuilt on every `ListToolsRequestSchema` request
* Scans filesystem for new/removed skills
* New skills appear in tool list immediately ✅

**Content (Skill Loading):**
* Before: Checked cache → returned cached content → never re-read from disk ❌
* After: Always reads from disk → returns fresh content → edits apply immediately ✅

## Benefits

✅ Immediate updates - Edit a skill and use it right away  
✅ Better DX - No restart needed for any skill changes  
✅ Faster iteration - Quick feedback loop for skill development  
✅ Accurate documentation - Docs now match actual behavior  
✅ Simplified codebase - Less state to manage, one less Map to track

## Performance Considerations

**Impact:** Minimal

* File reads are fast (typically < 1ms for small text files)
* Skills are only loaded when explicitly requested via `get_skill`
* Most skills are a few KB of markdown text
* The registry is still cached (only cleared on tool list requests)

**Tradeoff:** We trade a small amount of I/O overhead for significantly better UX and simpler code.

## Testing

✅ All tests pass: 87/87 tests passing  
✅ Build successful: No TypeScript errors  
✅ E2E tests: All 11 subprocess/stdio tests pass  
✅ Updated test: Verifies hot reload behavior (no caching)

## Breaking Changes

None. This is purely an internal implementation change. The external API remains identical.

## Implementation Details

**Before:**
```typescript
async loadSkill(skillName: string): Promise<Skill> {
  const cachedSkill = this.skillCache.get(skillName);
  if (cachedSkill) {
    return cachedSkill;  // ❌ Returns stale data
  }
  // ... load from disk and cache
  this.skillCache.set(skillName, skill);
  return skill;
}
```

**After:**
```typescript
async loadSkill(skillName: string): Promise<Skill> {
  // ... load from disk
  return skill;  // ✅ Always fresh data
}
```

## Related Context

This PR builds on the existing hot reload infrastructure:
* `src/index.ts:150-152` - Registry refreshes on each tool list request
* `src/skill-loader.ts:99-100` - Registry clears and rebuilds from filesystem

Now both discovery AND loading are cache-free, providing complete hot reload.