### PR TITLE
fix: update release workflow to create PR instead of direct push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+
+      - name: Create Pull Request for Release Changes
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(release): update changelog and version [skip ci]"
+          branch: release-updates
+          delete-branch: true
+          title: "chore(release): update changelog and version"
+          body: |
+            This PR contains automated updates from the release workflow:
+            - Updated CHANGELOG.md
+            - Updated package.json and package-lock.json with new version
+
+            This PR was automatically created by the release workflow.
+          base: main
+          labels: release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -85,13 +85,6 @@
           { "path": "CHANGELOG.md", "label": "Changelog" }
         ]
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
     ]
   ]
 }


### PR DESCRIPTION
## Problem

The release workflow was failing due to branch protection rules on `main`:

remote: error: GH013: Repository rule violations found for refs/heads/main. remote: - Changes must be made through a pull request.

The `@semantic-release/git` plugin was attempting to push changelog and version updates directly to the `main` branch, which violated the repository's branch protection policy requiring all changes to go through pull requests.

## Solution

This PR implements a two-stage release process that complies with branch protection rules:

### Changes Made

1. **Removed `@semantic-release/git` plugin** from `.releaserc.json`
   - Prevents semantic-release from attempting direct pushes to main
   - All other plugins remain functional (npm publish, GitHub releases, changelog generation)

2. **Added automated PR creation** to `.github/workflows/release.yml`
   - Uses `peter-evans/create-pull-request@v6` action
   - Creates a PR with version and changelog updates after release
   - Automatically labels the PR as `release`

## How It Works

### Stage 1: Release Creation (Automated)
1. When commits are pushed to `main`, the release workflow triggers
2. Semantic-release analyzes commits using conventional commit standards
3. If a release is warranted:
   - Version is bumped in npm registry
   - GitHub release is created with release notes
   - CHANGELOG.md is updated locally
   - package.json and package-lock.json are updated locally

### Stage 2: PR Creation (Automated)
4. The `create-pull-request` action detects local file changes
5. Creates a new branch `release-updates` with these changes
6. Opens a PR to merge back to `main` with:
   - Commit message including `[skip ci]` to prevent infinite loops
   - Detailed description of changes
   - `release` label for easy filtering

### Stage 3: Manual Review (Required)
7. Team reviews the automated PR
8. Merge the PR to complete the release cycle
9. The `release-updates` branch is automatically deleted

## Benefits

- ✅ **Complies with branch protection** - All changes to main go through PRs
- ✅ **Maintains automation** - Release creation and npm publishing remain fully automated
- ✅ **Provides visibility** - Changelog and version updates are reviewable before merging
- ✅ **Prevents infinite loops** - `[skip ci]` tag prevents the release PR from triggering another release
- ✅ **Clean history** - Automated branch cleanup after merge

## Testing

To test this workflow:
1. Merge this PR to `main`
2. Make a commit following conventional commit format (e.g., `feat: add new feature`)
3. Push to `main`
4. Observe:
   - Release workflow runs successfully
   - GitHub release is created
   - NPM package is published
   - A PR is automatically created with version/changelog updates
5. Review and merge the automated PR

## Migration Notes

This is a **breaking change** to the release process:
- **Before**: Release workflow was fully automated end-to-end
- **After**: Requires manual merge of the auto-generated release PR

However, the core release functionality (npm publish, GitHub releases) remains fully automated. Only the version/changelog commits require PR review.

## Related Issues

Fixes the release workflow failure caused by branch protection rules requiring PRs for all changes to `main`.

---

### Files Changed

- `.releaserc.json` - Removed `@semantic-release/git` plugin configuration
- `.github/workflows/release.yml` - Added `create-pull-request` step after semantic-release
