### PR TITLE
fix: re-add @semantic-release/git plugin and sync version to 0.4.4

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -85,6 +85,13 @@
           { "path": "CHANGELOG.md", "label": "Changelog" }
         ]
       }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
     ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-skills-mcp",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Universal MCP server enabling any LLM or AI agent to utilize expert skills from your local filesystem. Reduces context consumption through lazy loading - only skill names visible initially, full content loads on-demand. Works with Claude, Cline, custom agents, and any MCP-compatible client.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Re-adds the `@semantic-release/git` plugin that was lost during merge and syncs package.json version to 0.4.4.

## What Happened
PR #55 added the `@semantic-release/git` plugin, but it was accidentally removed during the merge in commit `516c544` ("Merge branch 'main' into release-updates"). This caused the release workflow to:
- ✅ Publish v0.4.4 to npm successfully
- ✅ Create GitHub release v0.4.4 successfully  
- ❌ **NOT** commit the version bump back to the repository

## Current State
- GitHub release: `v0.4.4` ✅
- npm version: `0.4.4` ✅
- package.json on main: `0.4.3` ❌

## Changes in This PR
- ✅ Re-add `@semantic-release/git` plugin to `.releaserc.json`
- ✅ Update `package.json` version from `0.4.3` to `0.4.4`

## Why This Fixes It
The `@semantic-release/git` plugin is responsible for committing version bumps (package.json, package-lock.json, CHANGELOG.md) back to the repository after each release. Without it, the release happens on npm and GitHub, but the repository is never updated.

## Testing
Once merged, the next release will:
1. ✅ Update package.json, package-lock.json, and CHANGELOG.md  
2. ✅ Commit changes with message: `chore(release): <version> [skip ci]`
3. ✅ Push the commit to main (using GitHub Actions bypass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)