### PR TITLE
fix: use RELEASE_TOKEN to bypass repository rulesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
           persist-credentials: true
 
       - name: Setup Node.js
@@ -52,6 +53,6 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary
Updates the release workflow to use `RELEASE_TOKEN` (PAT) instead of `GITHUB_TOKEN` to bypass repository rulesets.

## Problem
The previous workflow failed with this error:
```
remote: - Changes must be made through a pull request.
! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

**Root cause:** The default `GITHUB_TOKEN` **cannot bypass repository rulesets by design**. This is a GitHub security limitation - even if you add "GitHub Actions" to the bypass list in the UI, it won't work with `GITHUB_TOKEN`.

## Solution
Use a Personal Access Token (PAT) with bypass permissions from an account that can bypass the rulesets.

## Changes
- ✅ Update `actions/checkout` to use `secrets.RELEASE_TOKEN` instead of default token
- ✅ Update semantic-release step to use `secrets.RELEASE_TOKEN` as `GITHUB_TOKEN`

The `RELEASE_TOKEN` secret has been created with:
- Fine-grained PAT from kdpa-llc owner account
- Repository access: `kdpa-llc/local-skills-mcp`
- Permissions: Contents (read/write)

## Testing
Once merged, the release workflow will:
1. ✅ Run semantic-release
2. ✅ Update package.json, package-lock.json, CHANGELOG.md via `@semantic-release/git`
3. ✅ Push commit to main (bypassing PR requirement using PAT)
4. ✅ Create GitHub release
5. ✅ Publish to npm

## References
- [Stack Overflow: Why bypass settings don't apply to GITHUB_TOKEN](https://stackoverflow.com/questions/77433427)
- GitHub rulesets require PAT for bypass, not GITHUB_TOKEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)