### PR TITLE
fix: skill_name traversal, get_skill name round-trip, and repo health

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -9,6 +9,7 @@ The `main` branch is the production-ready branch and has strict protection rules
 ### Required Settings
 
 #### Pull Request Requirements
+
 - **Require a pull request before merging**: Enabled
   - **Required approvals**: 1
   - **Dismiss stale reviews**: Enabled (when new commits are pushed)
@@ -16,23 +17,28 @@ The `main` branch is the production-ready branch and has strict protection rules
   - **Restrict who can dismiss pull request reviews**: Only maintainers
 
 #### Status Checks
+
 The following status checks must pass before merging:
+
 - `test` - Full test suite execution
 - `lint` - Code linting (ESLint)
 - `typecheck` - TypeScript type checking
 - `build` - Successful build verification
 
 **Additional Requirements**:
+
 - Require branches to be up to date before merging
 - Require status checks to pass
 
 #### Push Restrictions
+
 - **Restrict pushes that create matching branches**: Enabled
 - **Allowed to push**: `kdpa-llc/maintainers` team only
 - **Force pushes**: Disabled for everyone
 - **Branch deletions**: Disabled for everyone
 
 #### Additional Protections
+
 - **Require linear history**: Enabled (to maintain clean git history)
 - **Require signed commits**: Recommended but not enforced initially
 - **Include administrators**: Enabled (administrators must follow the same rules)
@@ -41,15 +47,18 @@ The following status checks must pass before merging:
 ### Security Configuration
 
 #### Dependency Scanning
+
 - **Dependabot alerts**: Enabled
 - **Dependabot security updates**: Enabled
 - **Dependency review**: Required for pull requests
 
 #### Secret Scanning
+
 - **Secret scanning**: Enabled
 - **Push protection**: Enabled (prevents accidental secret commits)
 
 #### Code Scanning
+
 - **CodeQL analysis**: Enabled
 - Run on: Pull requests, pushes to main, and weekly schedule
 - Languages: TypeScript/JavaScript
@@ -77,6 +86,7 @@ The following status checks must pass before merging:
 ### When to Bypass Protection
 
 Branch protection should only be bypassed in true emergencies:
+
 - Critical security vulnerability requiring immediate hotfix
 - Production-breaking bug that needs urgent resolution
 - Infrastructure issue preventing normal PR workflow
@@ -102,6 +112,7 @@ Branch protection should only be bypassed in true emergencies:
    - Update documentation or processes as needed
 
 5. **Emergency Hotfix Process**:
+
    ```bash
    # Create hotfix branch from main
    git checkout main
@@ -127,6 +138,7 @@ Branch protection should only be bypassed in true emergencies:
 ## Tag Protection
 
 Version tags are also protected:
+
 - **Protected tag pattern**: `v*` (all version tags)
 - **Allowed to create**: `kdpa-llc/maintainers` team only
 - **Prevent tag deletion**: Enabled
@@ -136,17 +148,20 @@ This ensures release versions are immutable and traceable.
 ## Team Roles and Access
 
 ### Maintainers Team (`kdpa-llc/maintainers`)
+
 - Can approve and merge pull requests
 - Can create protected branches
 - Can create version tags
 - Subject to all protection rules (except administrators in emergencies)
 
 ### Core Team (`kdpa-llc/core-team`)
+
 - Code owners for source code
 - Reviews required for src/ changes
 - Cannot merge without maintainer approval
 
 ### Contributors
+
 - Can create pull requests
 - Can review code (non-binding)
 - Cannot push directly to protected branches
@@ -156,6 +171,7 @@ This ensures release versions are immutable and traceable.
 To verify branch protection is working correctly:
 
 1. **Test Direct Push** (should fail):
+
    ```bash
    git checkout main
    git commit --allow-empty -m "Test commit"
@@ -164,6 +180,7 @@ To verify branch protection is working correctly:
    ```
 
 2. **Test Force Push** (should fail):
+
    ```bash
    git push --force origin main
    # Expected: Error - force push not allowed
@@ -190,6 +207,7 @@ To verify branch protection is working correctly:
 ## Maintenance
 
 This document should be reviewed and updated:
+
 - When protection rules change
 - Quarterly as part of security review
 - After any emergency bypass incident

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,41 +1,50 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: '[BUG] '
+title: "[BUG] "
 labels: bug
-assignees: ''
+assignees: ""
 ---
 
 ## Describe the bug
+
 A clear and concise description of what the bug is.
 
 ## To Reproduce
+
 Steps to reproduce the behavior:
+
 1. Configure MCP with '...'
 2. Run command '...'
 3. See error
 
 ## Expected behavior
+
 A clear and concise description of what you expected to happen.
 
 ## Actual behavior
+
 What actually happened.
 
 ## Environment
+
 - Node version: [e.g. 18.0.0]
 - Local Skills MCP version: [e.g. 2.2.0]
 - OS: [e.g. macOS 14.0]
 - MCP Client: [e.g. Claude Code, Claude Desktop]
 
 ## Skill Configuration
+
 - Number of skills:
 - Skill directories used: [e.g. ~/.claude/skills, ./skills]
 - Custom SKILLS_DIR: [yes/no]
 
 ## Logs/Error Messages
+
 ```
 Paste any relevant logs or error messages here
 ```
 
 ## Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,25 +1,31 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: '[FEATURE] '
+title: "[FEATURE] "
 labels: enhancement
-assignees: ''
+assignees: ""
 ---
 
 ## Is your feature request related to a problem?
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 ## Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
 ## Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 ## Use case
+
 Describe how this feature would be used and who would benefit from it.
 
 ## Additional context
+
 Add any other context, screenshots, or examples about the feature request here.
 
 ## Implementation ideas
+
 If you have thoughts on how this could be implemented, please share them here.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,12 @@ updates:
       - "automated"
     # Allow both direct and indirect updates
     open-pull-requests-limit: 5
-    # Prefix commit messages
+    # Prefix commit messages.
+    # Production bumps use "fix" so a runtime dependency update — including a
+    # security patch that auto-merges — cuts a patch release on its own.
+    # Development bumps stay "chore", which .releaserc.json maps to no release.
     commit-message:
-      prefix: "chore"
+      prefix: "fix"
       prefix-development: "chore"
       include: "scope"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run linter
         run: npm run lint
 
+      - name: Check formatting
+        run: npm run format:check
+
       - name: Run type check
         run: npm run typecheck
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,6 @@ CLAUDE.md
 # Generated files
 server.json
 
-# Eval/benchmark results
-evals/
+# Eval/benchmark run artifacts (generated).
+# The curated eval sets in evals/*.json are inputs and stay tracked.
+evals/results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## <small>0.4.4 (2025-11-11)</small>
+
+- fix: add @semantic-release/git plugin and sync version to 0.4.3 ([4b5ef0c](https://github.com/kdpa-llc/local-skills-mcp/commit/4b5ef0c))
+
+## <small>0.4.3 (2025-11-11)</small>
+
+- fix: revert release workflow to direct commits instead of PR creation ([3390139](https://github.com/kdpa-llc/local-skills-mcp/commit/3390139))
+
 ## <small>0.4.2 (2025-11-11)</small>
 
 - docs: add npm downloads and types badges to README ([110c285](https://github.com/kdpa-llc/local-skills-mcp/commit/110c285))

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -105,7 +105,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing to Local Skills MCP! We welcome cont
 ### Reporting Bugs
 
 If you find a bug, please open an issue on GitHub with:
+
 - A clear, descriptive title
 - Steps to reproduce the issue
 - Expected behavior
@@ -17,6 +18,7 @@ If you find a bug, please open an issue on GitHub with:
 ### Suggesting Features
 
 We welcome feature suggestions! Please open an issue with:
+
 - A clear description of the feature
 - The problem it solves
 - Any examples or use cases
@@ -25,6 +27,7 @@ We welcome feature suggestions! Please open an issue with:
 ### Pull Requests
 
 1. **Fork the repository** and create your branch from `main`
+
    ```bash
    git checkout -b feature/your-feature-name
    ```
@@ -36,6 +39,7 @@ We welcome feature suggestions! Please open an issue with:
    - Update documentation as needed
 
 3. **Test your changes**
+
    ```bash
    npm install
    npm run build
@@ -192,6 +196,7 @@ For manual verification:
 ## Documentation
 
 When adding features or changing functionality:
+
 - Update README.md
 - Update QUICK_START.md if needed
 - Add/update code comments

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -32,32 +32,32 @@ Add the MCP server to your Claude Code configuration file:
 **Location:** `~/.config/claude-code/mcp.json` (Linux/Mac) or `%APPDATA%/claude-code/mcp.json` (Windows)
 
 **Option A: Auto-detect skills directory (Recommended)**
+
 ```json
 {
   "mcpServers": {
     "local-skills": {
       "command": "node",
-      "args": [
-        "/full/path/to/local-skills-mcp/dist/index.js"
-      ]
+      "args": ["/full/path/to/local-skills-mcp/dist/index.js"]
     }
   }
 }
 ```
+
 The server will automatically find skills in this priority order:
+
 1. `~/.claude/skills/` (if exists)
 2. `./.claude/skills/` (if exists)
 3. `./skills` (fallback)
 
 **Option B: Explicit skills directory**
+
 ```json
 {
   "mcpServers": {
     "local-skills": {
       "command": "node",
-      "args": [
-        "/full/path/to/local-skills-mcp/dist/index.js"
-      ],
+      "args": ["/full/path/to/local-skills-mcp/dist/index.js"],
       "env": {
         "SKILLS_DIR": "/full/path/to/local-skills-mcp/skills"
       }
@@ -65,6 +65,7 @@ The server will automatically find skills in this priority order:
   }
 }
 ```
+
 Use this if you want to explicitly specify where skills are stored.
 
 **Important:** Replace `/full/path/to/local-skills-mcp` with the actual absolute path to where you cloned the repository.
@@ -81,7 +82,7 @@ Open Claude Code and try these commands:
 List all available skills
 ```
 
-Claude will use the `list_skills` MCP tool and show you all available skills.
+Claude will read the skill list from the `get_skill` tool description, which names every discovered skill.
 
 ```
 Use the code-reviewer skill to review this code: [paste code here]
@@ -155,11 +156,13 @@ You are an expert at [domain].
 Your task is to [specific task].
 
 Guidelines:
+
 1. First guideline
 2. Second guideline
 ```
 
 **Required:**
+
 - YAML frontmatter between `---` markers
 - `name` field (lowercase, hyphens allowed)
 - `description` field
@@ -172,6 +175,7 @@ Guidelines:
 **Symptom:** Claude says it doesn't have access to local-skills tools
 
 **Solution:**
+
 1. Check the path in `mcp.json` is correct and absolute
 2. Verify `dist/index.js` exists: `ls dist/index.js`
 3. Rebuild if needed: `npm run build`
@@ -179,9 +183,10 @@ Guidelines:
 
 ### No Skills Found
 
-**Symptom:** `list_skills` returns "No skills found"
+**Symptom:** The `get_skill` tool description lists no skills
 
 **Solution:**
+
 1. Check `SKILLS_DIR` path is correct
 2. Verify skills directory exists: `ls skills/`
 3. Check example skills are present: `ls skills/code-reviewer/SKILL.md`
@@ -191,6 +196,7 @@ Guidelines:
 **Symptom:** `npm install` or `npm run build` fails
 
 **Solution:**
+
 1. Check Node.js version: `node --version` (should be 18+)
 2. Remove node_modules: `rm -rf node_modules`
 3. Clear npm cache: `npm cache clean --force`
@@ -201,6 +207,7 @@ Guidelines:
 **Symptom:** Skill fails to load with YAML error
 
 **Solution:**
+
 1. Ensure SKILL.md starts with `---\n`
 2. Ensure frontmatter ends with `\n---\n`
 3. Check YAML syntax (no tabs, proper format)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ description: What this skill does and when to use it
 You are an expert at [domain]. Your task is to [specific task].
 
 Guidelines:
+
 1. Be specific and actionable
 2. Provide examples
 3. Include best practices
@@ -194,10 +195,12 @@ Your skill instructions in Markdown format...
 Use pattern: `[What it does]. Use when [trigger conditions/keywords].`
 
 ✅ **Good Examples:**
+
 - "Generates clear commit messages from git diffs. Use when writing commit messages or reviewing staged changes."
 - "Analyzes Excel spreadsheets and creates pivot tables. Use when working with .xlsx files or tabular data."
 
 ❌ **Poor Example:**
+
 - "Helps with Excel files"
 
 Specific trigger keywords help the AI make better decisions when selecting skills.
@@ -213,6 +216,7 @@ Specific trigger keywords help the AI make better decisions when selecting skill
 **Built-in Skills:**
 
 Three self-documenting skills are included:
+
 - `local-skills-mcp-usage` - Quick usage guide
 - `local-skills-mcp-guide` - Comprehensive documentation
 - `skill-creator` - Skill authoring best practices
@@ -220,6 +224,7 @@ Three self-documenting skills are included:
 **Skill Directories:**
 
 Auto-aggregates from multiple locations (later ones override earlier):
+
 1. Package built-in skills
 2. `~/.claude/skills/` - Global skills
 3. `./.claude/skills/` - Project-specific (hidden)
@@ -254,6 +259,7 @@ description: Reviews code for best practices, bugs, and security. Use when revie
 You are a code reviewer with expertise in software engineering best practices.
 
 Analyze the code for:
+
 1. Correctness and bugs
 2. Best practices and maintainability
 3. Performance and security issues
@@ -331,10 +337,12 @@ This project follows a [Code of Conduct][code-of-conduct].
 While Local Skills MCP provides expert prompt instructions, [MCP Compression Proxy][mcp-tool-aggregator] optimizes your tool descriptions with intelligent LLM-based compression.
 
 **Perfect combination:**
+
 - **Local Skills MCP** - Expert skills with lazy loading (~50 tokens/skill)
 - **MCP Compression Proxy** - Compressed tool descriptions (50-80% token reduction)
 
 **Together they enable:**
+
 - 🎯 Maximum context efficiency across skills AND tools
 - 🔗 Access to multiple MCP servers through one connection
 - ⚡ Minimal token consumption for large-scale workflows

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,6 +87,7 @@ When using Local Skills MCP:
 ## Security Updates
 
 Security updates will be:
+
 - Released as patch versions (e.g., 0.1.1)
 - Documented in CHANGELOG.md
 - Announced in the release notes

--- a/docs/API.md
+++ b/docs/API.md
@@ -32,15 +32,23 @@ The main MCP server class that handles client connections and manages the skill 
 #### Constructor
 
 ```typescript
-constructor();
+constructor(skillsDirs?: string[]);
 ```
 
 Creates a new LocalSkillsServer instance with the following behavior:
 
 - Initializes the MCP server with name and version from package.json
-- Creates a SkillLoader with all configured skill directories
+- Creates a SkillLoader for `skillsDirs`, defaulting to the directories
+  returned by [getAllSkillsDirectories()](#getallskillsdirectories)
 - Sets up request handlers for listing and calling tools
 - Configures error handling and graceful shutdown
+
+**Parameters:**
+
+- **skillsDirs** _(optional)_: Directories to serve skills from. Pass an
+  explicit list to serve a fixed set instead of the default locations — useful
+  for embedding the server, and for tests that must not depend on whatever the
+  host machine has in `~/.claude/skills`.
 
 **Example:**
 
@@ -49,6 +57,12 @@ import { LocalSkillsServer } from "local-skills-mcp";
 
 const server = new LocalSkillsServer();
 await server.run();
+```
+
+```typescript
+// Serve only these directories
+const scoped = new LocalSkillsServer(["/srv/team-skills"]);
+await scoped.run();
 ```
 
 #### Methods
@@ -245,7 +259,8 @@ Complete skill definition including metadata and content.
 
 ```typescript
 interface Skill {
-  name: string; // Display name from YAML frontmatter
+  name: string; // Directory name — the key get_skill accepts
+  title: string; // Display name from YAML frontmatter
   description: string; // Description from YAML frontmatter
   content: string; // Full markdown content after frontmatter
   path: string; // Absolute path to skill directory
@@ -255,7 +270,11 @@ interface Skill {
 
 **Properties:**
 
-- **name**: The skill's display name as specified in SKILL.md frontmatter
+- **name**: The skill's directory name. This is the identity: skills are
+  discovered and registered by directory name, so this is the value that can be
+  passed back to `get_skill` to fetch the same skill again.
+- **title**: The display name from SKILL.md frontmatter. Free-form, and not
+  required to match the directory name — so it is not a lookup key.
 - **description**: A brief description of the skill's purpose
 - **content**: The complete skill prompt/instructions (markdown after frontmatter)
 - **path**: Absolute filesystem path to the skill's directory
@@ -265,7 +284,8 @@ interface Skill {
 
 ```typescript
 const skill: Skill = {
-  name: "Code Reviewer",
+  name: "code-reviewer",
+  title: "Code Reviewer",
   description: "Expert code review assistant",
   content: "# Instructions\n\nYou are an expert code reviewer...",
   path: "/home/user/.claude/skills/code-reviewer",
@@ -417,6 +437,7 @@ directories the server was told to serve.
 ```markdown
 # Skill: {name}
 
+**Title:** {title}
 **Description:** {description}
 **Source:** {source}
 
@@ -424,6 +445,10 @@ directories the server was told to serve.
 
 {content}
 ```
+
+`{name}` is the skill's directory name, so it can be passed straight back to
+`get_skill`. The `**Title:**` line appears only when the frontmatter name
+differs from the directory name.
 
 **Example Request:**
 
@@ -442,8 +467,9 @@ directories the server was told to serve.
 **Example Response:**
 
 ```markdown
-# Skill: Code Reviewer
+# Skill: code-reviewer
 
+**Title:** Code Reviewer
 **Description:** Expert code review assistant
 **Source:** /home/user/.claude/skills
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,6 +12,14 @@ This document provides detailed API documentation for the local-skills-mcp packa
   - [SkillMetadata](#skillmetadata)
 - [Utility Functions](#utility-functions)
   - [getAllSkillsDirectories](#getallskillsdirectories)
+- [MCP Protocol Integration](#mcp-protocol-integration)
+  - [get_skill](#get_skill)
+  - [validate_skill](#validate_skill)
+  - [evaluate_skill](#evaluate_skill)
+- [Error Handling](#error-handling)
+- [Best Practices](#best-practices)
+- [TypeScript Usage](#typescript-usage)
+- [Version Information](#version-information)
 
 ---
 
@@ -24,10 +32,11 @@ The main MCP server class that handles client connections and manages the skill 
 #### Constructor
 
 ```typescript
-constructor()
+constructor();
 ```
 
 Creates a new LocalSkillsServer instance with the following behavior:
+
 - Initializes the MCP server with name and version from package.json
 - Creates a SkillLoader with all configured skill directories
 - Sets up request handlers for listing and calling tools
@@ -36,7 +45,7 @@ Creates a new LocalSkillsServer instance with the following behavior:
 **Example:**
 
 ```typescript
-import { LocalSkillsServer } from 'local-skills-mcp';
+import { LocalSkillsServer } from "local-skills-mcp";
 
 const server = new LocalSkillsServer();
 await server.run();
@@ -53,6 +62,7 @@ async run(): Promise<void>
 Starts the MCP server and connects it to stdio transport for communication.
 
 **Behavior:**
+
 - Creates a stdio transport for MCP communication
 - Connects the server to the transport
 - Logs server startup information to stderr
@@ -67,6 +77,7 @@ await server.run();
 ```
 
 **Output:**
+
 ```
 Local Skills MCP Server v0.1.0 running on stdio
 Aggregating skills from 3 directories:
@@ -90,16 +101,17 @@ constructor(skillsPaths: string[])
 Creates a new SkillLoader instance that monitors the specified directories.
 
 **Parameters:**
+
 - `skillsPaths` (string[]): Array of directory paths to search for skills
 
 **Example:**
 
 ```typescript
-import { SkillLoader } from 'local-skills-mcp';
+import { SkillLoader } from "local-skills-mcp";
 
 const loader = new SkillLoader([
-  '/home/user/.claude/skills',
-  '/home/user/project/skills'
+  "/home/user/.claude/skills",
+  "/home/user/project/skills",
 ]);
 ```
 
@@ -114,9 +126,11 @@ async discoverSkills(): Promise<string[]>
 Scans all configured directories and returns a list of available skill names.
 
 **Returns:**
+
 - Promise<string[]>: Sorted array of skill names
 
 **Behavior:**
+
 - Clears and rebuilds the internal skill registry
 - Scans each directory for subdirectories containing `SKILL.md`
 - Later directories override earlier ones for duplicate skill names
@@ -140,16 +154,20 @@ async loadSkill(skillName: string): Promise<Skill>
 Loads a specific skill by name, including its full content and metadata.
 
 **Parameters:**
+
 - `skillName` (string): The name of the skill to load
 
 **Returns:**
+
 - Promise<Skill>: Complete skill object with metadata and content
 
 **Throws:**
+
 - Error if skill is not found in the registry
 - Error if SKILL.md file cannot be read or parsed
 
 **Behavior:**
+
 - Checks cache first for previously loaded skills
 - Loads and parses the SKILL.md file
 - Validates YAML frontmatter
@@ -159,11 +177,11 @@ Loads a specific skill by name, including its full content and metadata.
 **Example:**
 
 ```typescript
-const skill = await loader.loadSkill('code-reviewer');
-console.log(skill.name);        // 'Code Reviewer'
+const skill = await loader.loadSkill("code-reviewer");
+console.log(skill.name); // 'Code Reviewer'
 console.log(skill.description); // 'Expert code review assistant'
-console.log(skill.content);     // Full skill prompt content
-console.log(skill.source);      // '/home/user/.claude/skills'
+console.log(skill.content); // Full skill prompt content
+console.log(skill.source); // '/home/user/.claude/skills'
 ```
 
 ##### getSkillMetadata()
@@ -175,22 +193,25 @@ async getSkillMetadata(skillName: string): Promise<SkillMetadata & { source: str
 Retrieves skill metadata without loading the full content (lightweight operation).
 
 **Parameters:**
+
 - `skillName` (string): The name of the skill
 
 **Returns:**
+
 - Promise<SkillMetadata & { source: string }>: Metadata with source directory
 
 **Throws:**
+
 - Error if skill is not found
 - Error if SKILL.md cannot be parsed
 
 **Example:**
 
 ```typescript
-const metadata = await loader.getSkillMetadata('code-reviewer');
-console.log(metadata.name);        // 'Code Reviewer'
+const metadata = await loader.getSkillMetadata("code-reviewer");
+console.log(metadata.name); // 'Code Reviewer'
 console.log(metadata.description); // 'Expert code review assistant'
-console.log(metadata.source);      // '/home/user/.claude/skills'
+console.log(metadata.source); // '/home/user/.claude/skills'
 // Note: metadata.content is NOT included (saves memory)
 ```
 
@@ -203,6 +224,7 @@ getSkillsPaths(): string[]
 Returns the array of directories being monitored for skills.
 
 **Returns:**
+
 - string[]: Array of skill directory paths
 
 **Example:**
@@ -223,11 +245,11 @@ Complete skill definition including metadata and content.
 
 ```typescript
 interface Skill {
-  name: string;        // Display name from YAML frontmatter
+  name: string; // Display name from YAML frontmatter
   description: string; // Description from YAML frontmatter
-  content: string;     // Full markdown content after frontmatter
-  path: string;        // Absolute path to skill directory
-  source: string;      // Source directory (which skills path)
+  content: string; // Full markdown content after frontmatter
+  path: string; // Absolute path to skill directory
+  source: string; // Source directory (which skills path)
 }
 ```
 
@@ -243,11 +265,11 @@ interface Skill {
 
 ```typescript
 const skill: Skill = {
-  name: 'Code Reviewer',
-  description: 'Expert code review assistant',
-  content: '# Instructions\n\nYou are an expert code reviewer...',
-  path: '/home/user/.claude/skills/code-reviewer',
-  source: '/home/user/.claude/skills'
+  name: "Code Reviewer",
+  description: "Expert code review assistant",
+  content: "# Instructions\n\nYou are an expert code reviewer...",
+  path: "/home/user/.claude/skills/code-reviewer",
+  source: "/home/user/.claude/skills",
 };
 ```
 
@@ -259,7 +281,7 @@ Metadata extracted from SKILL.md YAML frontmatter.
 
 ```typescript
 interface SkillMetadata {
-  name: string;        // Skill display name
+  name: string; // Skill display name
   description: string; // Brief description
 }
 ```
@@ -282,8 +304,8 @@ description: Expert code review assistant with focus on best practices
 
 ```typescript
 const metadata: SkillMetadata = {
-  name: 'Code Reviewer',
-  description: 'Expert code review assistant with focus on best practices'
+  name: "Code Reviewer",
+  description: "Expert code review assistant with focus on best practices",
 };
 ```
 
@@ -294,15 +316,17 @@ const metadata: SkillMetadata = {
 ### getAllSkillsDirectories()
 
 ```typescript
-export function getAllSkillsDirectories(): string[]
+export function getAllSkillsDirectories(): string[];
 ```
 
 Determines all directories to scan for skills based on standard locations and environment variables.
 
 **Returns:**
+
 - string[]: Array of directory paths in priority order
 
 **Behavior:**
+
 - Checks for `~/.claude/skills` (user-level Claude skills)
 - Checks for `{cwd}/.claude/skills` (project-level Claude skills)
 - Checks for `{cwd}/skills` (default project skills)
@@ -311,6 +335,7 @@ Determines all directories to scan for skills based on standard locations and en
 - Returns at least one path (default: `{cwd}/skills`)
 
 **Priority Order for Duplicate Skills:**
+
 1. `SKILLS_DIR` environment variable (highest priority)
 2. `{cwd}/skills`
 3. `{cwd}/.claude/skills`
@@ -319,7 +344,7 @@ Determines all directories to scan for skills based on standard locations and en
 **Example:**
 
 ```typescript
-import { getAllSkillsDirectories } from 'local-skills-mcp';
+import { getAllSkillsDirectories } from "local-skills-mcp";
 
 const dirs = getAllSkillsDirectories();
 console.log(dirs);
@@ -364,18 +389,26 @@ Retrieves a skill's content and metadata.
 
 ```typescript
 {
-  skill_name: string  // Required: name of the skill to retrieve
+  skill_name: string; // Required: name of the skill to retrieve
 }
 ```
+
+`skill_name` is a single directory name, not a path. Values containing `/`,
+`\`, or a null byte — and the relative references `.` and `..` — are rejected,
+and a resolved skill directory must stay inside one of the configured skills
+directories. This keeps tool calls from reaching `SKILL.md` files outside the
+directories the server was told to serve.
 
 **Response Format:**
 
 ```typescript
 {
-  content: [{
-    type: 'text',
-    text: string  // Formatted skill output with metadata and content
-  }]
+  content: [
+    {
+      type: "text",
+      text: string, // Formatted skill output with metadata and content
+    },
+  ];
 }
 ```
 
@@ -423,6 +456,80 @@ You are an expert code reviewer...
 
 ---
 
+#### validate_skill
+
+Validates a skill's `SKILL.md` against the frontmatter rules and returns
+structured errors and warnings.
+
+**Input Schema:**
+
+```typescript
+{
+  skill_name: string; // Required: the skill directory name to validate
+}
+```
+
+**Response Format:**
+
+The response text is a JSON document:
+
+```json
+{
+  "valid": false,
+  "errors": [
+    "Skill name must be kebab-case (lowercase letters, numbers, hyphens)"
+  ],
+  "warnings": ["Description should include a \"Use when ...\" trigger phrase."]
+}
+```
+
+`errors` block a skill from being considered valid; `warnings` are advisory and
+flag things that hurt skill routing, such as a short description or a missing
+"Use when" trigger phrase.
+
+#### evaluate_skill
+
+Runs the Anthropic skill-creator eval loop against a skill to measure and
+improve how reliably its description triggers.
+
+**Requirements:** Python, an authenticated Claude CLI, and an eval set JSON.
+Legacy `run_loop.py` layouts additionally require `ANTHROPIC_API_KEY` and the
+`anthropic` Python package.
+
+**Input Schema:**
+
+```typescript
+{
+  skill_name: string             // Required: the skill directory name
+  eval_set_path?: string         // Path to an eval set JSON
+  max_iterations?: number        // Max optimization iterations
+  num_workers?: number           // Evaluator parallelism (default 1)
+  runs_per_query?: number        // Repeats per query (default 1)
+  timeout_seconds?: number       // Per-query timeout (default 120)
+  holdout?: number               // Holdout fraction, 0-1 (default 0.4)
+  trigger_threshold?: number     // Pass/fail trigger rate, 0-1 (default 0.5)
+  description_override?: string  // Try a description without editing SKILL.md
+  model?: string                 // Model for the Claude CLI (default "sonnet")
+}
+```
+
+Optional arguments are type-checked: a string argument passed a number (or a
+numeric argument passed a string or a non-finite value) is rejected rather than
+forwarded to the eval runner.
+
+When `eval_set_path` is omitted, these locations are checked in order:
+
+```
+<skill-dir>/eval-set.json
+<skill-dir>/eval_set.json
+<skill-dir>/evals.json
+<skill-dir>/evals/eval-set.json
+<skill-dir>/evals/eval_set.json
+<repo-root>/evals/<skill_name>.json
+```
+
+---
+
 ## Error Handling
 
 ### Common Errors
@@ -430,12 +537,23 @@ You are an expert code reviewer...
 #### Skill Not Found
 
 ```typescript
-Error: Skill "unknown-skill" not found. Run list_skills to see available skills.
+Error: Skill "unknown-skill" not found. Available skills: code-reviewer, test-generator
 ```
 
 **Cause:** Requested skill name doesn't exist in any monitored directory
 
-**Solution:** Call `discoverSkills()` to get available skills
+**Solution:** The error lists the skills that were discovered; use one of those
+names. The full list is also carried in the `get_skill` tool description.
+
+#### Invalid Skill Name
+
+```typescript
+Error: Invalid skill_name "../../etc". A skill name is a single directory name, not a path.
+```
+
+**Cause:** `skill_name` contained a path separator, a null byte, or was `.` / `..`
+
+**Solution:** Pass the skill's directory name on its own, e.g. `code-reviewer`
 
 #### Invalid SKILL.md Format
 
@@ -446,6 +564,7 @@ Error: SKILL.md must start with YAML frontmatter (---)
 **Cause:** SKILL.md file doesn't begin with `---` delimiter
 
 **Solution:** Ensure SKILL.md follows the correct format:
+
 ```markdown
 ---
 name: Skill Name
@@ -464,6 +583,7 @@ Error: SKILL.md frontmatter must include "name" field
 **Cause:** YAML frontmatter is missing required `name` or `description`
 
 **Solution:** Add both required fields to frontmatter:
+
 ```yaml
 ---
 name: My Skill
@@ -478,6 +598,7 @@ description: What this skill does
 ### Skill Organization
 
 1. **Directory Structure:**
+
    ```
    skills/
    ├── code-reviewer/
@@ -489,6 +610,7 @@ description: What this skill does
    ```
 
 2. **SKILL.md Format:**
+
    ```markdown
    ---
    name: Clear Descriptive Name
@@ -512,6 +634,7 @@ description: What this skill does
 ### Error Recovery
 
 The system is designed to be resilient:
+
 - Non-existent directories are silently skipped
 - Malformed skills don't prevent other skills from loading
 - Directory scan errors are logged but don't crash the server
@@ -532,33 +655,33 @@ Types are included in the package - no separate @types package needed.
 
 ```typescript
 // Import main server
-import { LocalSkillsServer } from 'local-skills-mcp';
+import { LocalSkillsServer } from "local-skills-mcp";
 
 // Import utilities
-import { getAllSkillsDirectories } from 'local-skills-mcp';
+import { getAllSkillsDirectories } from "local-skills-mcp";
 
 // Import types
-import type { Skill, SkillMetadata } from 'local-skills-mcp';
+import type { Skill, SkillMetadata } from "local-skills-mcp";
 
 // Import loader (for custom usage)
-import { SkillLoader } from 'local-skills-mcp';
+import { SkillLoader } from "local-skills-mcp";
 ```
 
 ### Custom Integration Example
 
 ```typescript
-import { SkillLoader } from 'local-skills-mcp';
-import type { Skill } from 'local-skills-mcp';
+import { SkillLoader } from "local-skills-mcp";
+import type { Skill } from "local-skills-mcp";
 
 // Create custom loader
-const loader = new SkillLoader(['/custom/path']);
+const loader = new SkillLoader(["/custom/path"]);
 
 // Discover available skills
 const skills = await loader.discoverSkills();
-console.log('Available skills:', skills);
+console.log("Available skills:", skills);
 
 // Load a specific skill
-const skill: Skill = await loader.loadSkill('my-skill');
+const skill: Skill = await loader.loadSkill("my-skill");
 
 // Use the skill content
 console.log(skill.name);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -365,6 +365,7 @@ flowchart TD
 ### LocalSkillsServer
 
 **Responsibilities:**
+
 - Initialize and manage MCP server
 - Handle MCP protocol requests
 - Coordinate with SkillLoader
@@ -372,24 +373,28 @@ flowchart TD
 - Handle graceful shutdown
 
 **Key Methods:**
+
 - `setupHandlers()`: Register MCP request handlers
 - `setupErrorHandling()`: Configure error handlers and signals
 - `handleGetSkill()`: Process get_skill tool calls
 - `run()`: Start server and connect transport
 
 **State:**
+
 - `server`: MCP Server instance
 - `skillLoader`: SkillLoader instance
 
 ### SkillLoader
 
 **Responsibilities:**
+
 - Discover skills across multiple directories
 - Load and parse SKILL.md files
 - Maintain skill cache and registry
 - Validate skill format and metadata
 
 **Key Methods:**
+
 - `discoverSkills()`: Scan directories and build registry
 - `loadSkill()`: Load specific skill with caching
 - `parseSkillFile()`: Parse YAML frontmatter and content
@@ -397,6 +402,7 @@ flowchart TD
 - `getSkillsPaths()`: Return configured directories
 
 **State:**
+
 - `skillsPaths`: Array of directory paths
 - `skillCache`: Map of loaded skills
 - `skillRegistry`: Map of skill locations
@@ -440,12 +446,14 @@ Client Response
 **Decision**: Load skill content only when requested, not at startup.
 
 **Rationale:**
+
 - Reduces initial server startup time
 - Minimizes memory usage for unused skills
 - Allows quick tool listing without I/O delay
 - Scales better with large skill libraries
 
 **Trade-offs:**
+
 - First access to a skill has slight delay
 - Can't detect malformed skills until accessed
 
@@ -454,12 +462,14 @@ Client Response
 **Decision**: Support multiple skill directories with priority override.
 
 **Rationale:**
+
 - Enables global skills shared across projects
 - Allows per-project skill customization
 - Supports multiple team skill repositories
 - Maintains compatibility with Claude's `.claude/skills` convention
 
 **Trade-offs:**
+
 - More complex directory scanning logic
 - Potential for confusion about which skill version is active
 
@@ -468,12 +478,14 @@ Client Response
 **Decision**: Use YAML frontmatter in Markdown files for metadata.
 
 **Rationale:**
+
 - Human-readable and editable
 - Standard pattern (Jekyll, Hugo, etc.)
 - Separates metadata from content
 - Easy to parse with existing libraries
 
 **Trade-offs:**
+
 - Requires strict format validation
 - More complex parsing than pure JSON
 
@@ -482,12 +494,14 @@ Client Response
 **Decision**: Cache loaded skills in memory without TTL or invalidation.
 
 **Rationale:**
+
 - Simple implementation
 - Maximum performance for repeated access
 - Skills rarely change during server runtime
 - Process restarts are quick and easy
 
 **Trade-offs:**
+
 - Requires server restart to pick up skill changes
 - Memory grows with number of accessed skills
 - No automatic cache invalidation
@@ -497,12 +511,14 @@ Client Response
 **Decision**: Use stdio for MCP communication (not HTTP or WebSocket).
 
 **Rationale:**
+
 - Standard MCP pattern for local servers
 - Simple process communication
 - No port conflicts or firewall issues
 - Built-in backpressure handling
 
 **Trade-offs:**
+
 - Can't be accessed remotely
 - Single client per server instance
 - Debugging is harder (stdio is used for protocol)
@@ -535,11 +551,13 @@ Client Response
 ### Scalability
 
 **Tested Limits:**
+
 - 100+ skills per directory: ✓ Fast
 - 1000+ skills per directory: ✓ Acceptable (~100-200ms discovery)
 - Multiple directories: ✓ Linear scaling
 
 **Memory Usage:**
+
 - Server baseline: ~20-30 MB
 - Per cached skill: ~1-10 KB (depending on content size)
 - Expected total: < 100 MB for typical usage

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -57,6 +57,7 @@ npm install
 ```
 
 This will:
+
 - Install all dependencies
 - Run the `prepare` script which builds the TypeScript code
 - Create the `dist/` directory with compiled JavaScript
@@ -219,15 +220,15 @@ npm run test:ui
 **Example Unit Test:**
 
 ```typescript
-import { describe, it, expect } from 'vitest';
-import { SkillLoader } from './skill-loader.js';
+import { describe, it, expect } from "vitest";
+import { SkillLoader } from "./skill-loader.js";
 
-describe('SkillLoader', () => {
-  it('should discover skills in directory', async () => {
-    const loader = new SkillLoader(['./test-skills']);
+describe("SkillLoader", () => {
+  it("should discover skills in directory", async () => {
+    const loader = new SkillLoader(["./test-skills"]);
     const skills = await loader.discoverSkills();
 
-    expect(skills).toContain('test-skill');
+    expect(skills).toContain("test-skill");
   });
 });
 ```
@@ -235,17 +236,17 @@ describe('SkillLoader', () => {
 **Example Integration Test:**
 
 ```typescript
-import { describe, it, expect, beforeEach } from 'vitest';
-import { LocalSkillsServer } from './index.js';
+import { describe, it, expect, beforeEach } from "vitest";
+import { LocalSkillsServer } from "./index.js";
 
-describe('LocalSkillsServer Integration', () => {
+describe("LocalSkillsServer Integration", () => {
   let server: LocalSkillsServer;
 
   beforeEach(() => {
     server = new LocalSkillsServer();
   });
 
-  it('should handle get_skill request', async () => {
+  it("should handle get_skill request", async () => {
     // Test server request handling
   });
 });
@@ -306,8 +307,8 @@ Create `.vscode/launch.json`:
 
 ```typescript
 // Add debug logs (stderr for MCP compatibility)
-console.error('[DEBUG] Loading skill:', skillName);
-console.error('[DEBUG] Cache size:', this.skillCache.size);
+console.error("[DEBUG] Loading skill:", skillName);
+console.error("[DEBUG] Cache size:", this.skillCache.size);
 ```
 
 #### 2. VS Code Breakpoints
@@ -343,16 +344,19 @@ tail -f server.log
 ### Common Debug Scenarios
 
 **Skill not loading:**
+
 1. Check if SKILL.md exists: `ls skills/skill-name/SKILL.md`
 2. Verify YAML frontmatter format
 3. Check server logs for parse errors
 
 **MCP connection issues:**
+
 1. Verify `dist/index.js` exists and is executable
 2. Check MCP client configuration
 3. Review stdio communication in logs
 
 **Caching issues:**
+
 1. Restart server to clear cache
 2. Check `skillCache` contents with debug logs
 3. Verify `discoverSkills()` is called before `loadSkill()`
@@ -412,17 +416,19 @@ Use descriptive error messages with context:
 
 ```typescript
 // ✅ Good: Descriptive with context
-throw new Error(`Skill "${skillName}" not found. Run list_skills to see available skills.`);
+throw new Error(
+  `Skill "${skillName}" not found. Available skills: ${available.join(", ")}`
+);
 
 // ❌ Bad: Generic message
-throw new Error('Not found');
+throw new Error("Not found");
 ```
 
 #### 4. Documentation
 
 Use JSDoc for all public APIs:
 
-```typescript
+````typescript
 /**
  * Load a specific skill by name with lazy loading and caching.
  *
@@ -438,7 +444,7 @@ Use JSDoc for all public APIs:
 async function loadSkill(skillName: string): Promise<Skill> {
   // ...
 }
-```
+````
 
 #### 5. Async/Await
 
@@ -447,14 +453,13 @@ Prefer async/await over promises:
 ```typescript
 // ✅ Good: async/await
 async function loadSkill(skillName: string): Promise<Skill> {
-  const content = await fs.readFile(path, 'utf-8');
+  const content = await fs.readFile(path, "utf-8");
   return parseSkill(content);
 }
 
 // ❌ Bad: Promise chains
 function loadSkill(skillName: string): Promise<Skill> {
-  return fs.readFile(path, 'utf-8')
-    .then(content => parseSkill(content));
+  return fs.readFile(path, "utf-8").then((content) => parseSkill(content));
 }
 ```
 
@@ -464,21 +469,21 @@ function loadSkill(skillName: string): Promise<Skill> {
 
 ```typescript
 // 1. Imports (external first, then internal)
-import fs from 'fs/promises';
-import path from 'path';
-import { Skill } from './types.js';
+import fs from "fs/promises";
+import path from "path";
+import { Skill } from "./types.js";
 
 // 2. Constants
-const VERSION = '0.1.0';
+const VERSION = "0.1.0";
 
 // 3. Type definitions (if not in separate file)
-interface Config { }
+interface Config {}
 
 // 4. Functions (utility functions first)
-function helperFunction() { }
+function helperFunction() {}
 
 // 5. Classes
-export class MainClass { }
+export class MainClass {}
 
 // 6. Main execution (if applicable)
 if (import.meta.url === `file://${process.argv[1]}`) {
@@ -488,7 +493,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
 ### Linting (Future)
 
-*Note: Linting configuration coming soon. Planned tools:*
+_Note: Linting configuration coming soon. Planned tools:_
+
 - ESLint with TypeScript plugin
 - Prettier for formatting
 - Pre-commit hooks with Husky
@@ -500,21 +506,24 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 ### Adding a New Feature
 
 1. **Create a feature branch**:
+
    ```bash
    git checkout -b feature/my-new-feature
    ```
 
 2. **Write tests first** (TDD approach):
+
    ```typescript
    // src/my-feature.test.ts
-   describe('MyFeature', () => {
-     it('should do something', () => {
+   describe("MyFeature", () => {
+     it("should do something", () => {
        // Test implementation
      });
    });
    ```
 
 3. **Implement the feature**:
+
    ```typescript
    // src/my-feature.ts
    export function myFeature() {
@@ -528,6 +537,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
    - Add JSDoc comments
 
 5. **Test thoroughly**:
+
    ```bash
    npm run test:run
    npm run test:coverage
@@ -543,16 +553,18 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 ### Debugging a Failing Test
 
 1. **Run the specific test**:
+
    ```bash
    npm test -- skill-loader.test.ts
    ```
 
 2. **Add debug output**:
+
    ```typescript
-   it('should load skill', async () => {
-     console.log('Test data:', testData);
-     const result = await loadSkill('test');
-     console.log('Result:', result);
+   it("should load skill", async () => {
+     console.log("Test data:", testData);
+     const result = await loadSkill("test");
+     console.log("Result:", result);
      expect(result).toBeDefined();
    });
    ```
@@ -600,6 +612,7 @@ start docs/api/index.html  # Windows
 **Problem**: Changes in TypeScript not reflected in execution.
 
 **Solution**: Always build after changes:
+
 ```bash
 npm run build
 # Or use watch mode
@@ -611,13 +624,15 @@ npm run watch
 **Problem**: TypeScript imports without .js extension fail at runtime.
 
 **Correct**:
+
 ```typescript
-import { Skill } from './types.js';  // ✅ With .js
+import { Skill } from "./types.js"; // ✅ With .js
 ```
 
 **Incorrect**:
+
 ```typescript
-import { Skill } from './types';     // ❌ No extension
+import { Skill } from "./types"; // ❌ No extension
 ```
 
 ### 3. Async Error Handling
@@ -625,10 +640,11 @@ import { Skill } from './types';     // ❌ No extension
 **Problem**: Unhandled promise rejections.
 
 **Solution**: Always use try/catch with async:
+
 ```typescript
 async function loadSkill(name: string) {
   try {
-    const content = await fs.readFile(path, 'utf-8');
+    const content = await fs.readFile(path, "utf-8");
     return parseSkill(content);
   } catch (error) {
     throw new Error(`Failed to load skill: ${error.message}`);
@@ -641,12 +657,13 @@ async function loadSkill(name: string) {
 **Problem**: console.log() interferes with MCP protocol.
 
 **Solution**: Use console.error() for logging:
+
 ```typescript
 // ✅ Good: stderr
-console.error('Debug info:', data);
+console.error("Debug info:", data);
 
 // ❌ Bad: stdout (conflicts with MCP)
-console.log('Debug info:', data);
+console.log("Debug info:", data);
 ```
 
 ### 5. Testing with Cached Skills
@@ -654,6 +671,7 @@ console.log('Debug info:', data);
 **Problem**: Cached data from previous test runs.
 
 **Solution**: Clear cache in beforeEach:
+
 ```typescript
 beforeEach(() => {
   loader = new SkillLoader([testDir]);
@@ -666,14 +684,16 @@ beforeEach(() => {
 **Problem**: Unsafe type assertions hiding errors.
 
 **Avoid**:
+
 ```typescript
-const skill = data as Skill;  // Unsafe
+const skill = data as Skill; // Unsafe
 ```
 
 **Better**:
+
 ```typescript
 if (!isValidSkill(data)) {
-  throw new Error('Invalid skill format');
+  throw new Error("Invalid skill format");
 }
 const skill: Skill = data;
 ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,11 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ["*.config.ts", "*.config.js"],
+          allowDefaultProject: [
+            "*.config.ts",
+            "*.config.js",
+            "vitest.global-setup.ts",
+          ],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/evals/local-skills-mcp-guide.json
+++ b/evals/local-skills-mcp-guide.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "Explain how src/index.ts and src/skill-loader.ts work together in local-skills-mcp.",
+    "should_trigger": true
+  },
+  {
+    "query": "In this local-skills-mcp repo, where are the MCP tool handlers defined and how are they registered?",
+    "should_trigger": true
+  },
+  {
+    "query": "Walk me through getAllSkillsDirectories priority and override behavior in this codebase.",
+    "should_trigger": true
+  },
+  {
+    "query": "How does local-skills-mcp discover skills and merge metadata across directories?",
+    "should_trigger": true
+  },
+  {
+    "query": "Point me to where validate_skill and evaluate_skill are implemented in this repository.",
+    "should_trigger": true
+  },
+  {
+    "query": "How are integration tests structured in this local-skills-mcp project?",
+    "should_trigger": true
+  },
+  {
+    "query": "Where should I store a personal reusable skill: ~/.claude/skills or ./skills?",
+    "should_trigger": false
+  },
+  {
+    "query": "Generate a conventional commit message for these staged files.",
+    "should_trigger": false
+  },
+  {
+    "query": "Write a SQL query for monthly active users grouped by country.",
+    "should_trigger": false
+  },
+  {
+    "query": "Help me debug a React input lag issue in a controlled component.",
+    "should_trigger": false
+  },
+  {
+    "query": "Plan a 3-day Seattle trip with coffee shops and museums.",
+    "should_trigger": false
+  },
+  {
+    "query": "Set up an nginx reverse proxy with TLS on Ubuntu.",
+    "should_trigger": false
+  }
+]

--- a/evals/local-skills-mcp-usage.json
+++ b/evals/local-skills-mcp-usage.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "For Local Skills MCP, when should I put a skill in ~/.claude/skills versus ./skills?",
+    "should_trigger": true
+  },
+  {
+    "query": "Explain the directory precedence between ~/.claude/skills, ./.claude/skills, ./skills, and SKILLS_DIR.",
+    "should_trigger": true
+  },
+  {
+    "query": "Show me how to configure local-skills-mcp in Claude Code mcp.json.",
+    "should_trigger": true
+  },
+  {
+    "query": "How do I add a project-specific skill so my team gets it from git?",
+    "should_trigger": true
+  },
+  {
+    "query": "What is the fastest way to create a new skill folder and make it discoverable by Local Skills MCP?",
+    "should_trigger": true
+  },
+  {
+    "query": "How does Local Skills MCP hot-reload skill edits without restarting?",
+    "should_trigger": true
+  },
+  {
+    "query": "Explain the implementation details of skill metadata truncation in src/index.ts.",
+    "should_trigger": false
+  },
+  {
+    "query": "Review this Python function for performance issues and suggest optimizations.",
+    "should_trigger": false
+  },
+  {
+    "query": "Generate a docker-compose.yml for postgres + redis + api service.",
+    "should_trigger": false
+  },
+  {
+    "query": "What will the weather be in New York this weekend?",
+    "should_trigger": false
+  },
+  {
+    "query": "Write a SQL migration that adds an index to users(email).",
+    "should_trigger": false
+  },
+  {
+    "query": "Help me choose between an M3 MacBook Air and Pro.",
+    "should_trigger": false
+  }
+]

--- a/evals/skill-creator.json
+++ b/evals/skill-creator.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "Create a new SKILL.md for a code-review assistant and write a good description with clear Use when triggers.",
+    "should_trigger": true
+  },
+  {
+    "query": "Can you review my skill frontmatter and fix name/description issues?",
+    "should_trigger": true
+  },
+  {
+    "query": "I want to improve an existing skill's routing quality. Suggest better trigger keywords.",
+    "should_trigger": true
+  },
+  {
+    "query": "Help me author a complete SKILL.md template with role, task, constraints, and output format.",
+    "should_trigger": true
+  },
+  {
+    "query": "How do I validate a skill and interpret errors vs warnings?",
+    "should_trigger": true
+  },
+  {
+    "query": "Guide me through evaluating a skill description against an eval set.",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up nginx with Let's Encrypt for my VPS.",
+    "should_trigger": false
+  },
+  {
+    "query": "Debug this React useEffect dependency loop.",
+    "should_trigger": false
+  },
+  {
+    "query": "Write a SQL query to find duplicate rows in orders.",
+    "should_trigger": false
+  },
+  {
+    "query": "Plan a 5-day Tokyo itinerary with ramen spots.",
+    "should_trigger": false
+  },
+  {
+    "query": "Generate an incident response checklist for on-call rotation.",
+    "should_trigger": false
+  },
+  {
+    "query": "Explain Kubernetes HPA tuning strategies for CPU spikes.",
+    "should_trigger": false
+  }
+]

--- a/mcp-config-auto-detect.json
+++ b/mcp-config-auto-detect.json
@@ -2,9 +2,7 @@
   "mcpServers": {
     "local-skills-auto": {
       "command": "node",
-      "args": [
-        "/absolute/path/to/local-skills-mcp/dist/index.js"
-      ]
+      "args": ["/absolute/path/to/local-skills-mcp/dist/index.js"]
     }
   }
 }

--- a/mcp-config-example.json
+++ b/mcp-config-example.json
@@ -2,9 +2,7 @@
   "mcpServers": {
     "local-skills": {
       "command": "node",
-      "args": [
-        "/absolute/path/to/local-skills-mcp/dist/index.js"
-      ],
+      "args": ["/absolute/path/to/local-skills-mcp/dist/index.js"],
       "env": {
         "SKILLS_DIR": "/absolute/path/to/skills"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,12 +30,13 @@
         "@typescript-eslint/eslint-plugin": "^8.49.0",
         "@typescript-eslint/parser": "^8.49.0",
         "@vitest/coverage-v8": "^2.1.8",
+        "@vitest/ui": "^2.1.9",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
-        "prettier": "^3.8.1",
+        "prettier": "^3.7.4",
         "semantic-release": "^25.0.2",
         "typedoc": "^0.28.15",
         "typescript": "^5.9.3",
@@ -1490,6 +1491,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.5",
@@ -3082,6 +3090,28 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.1.9.tgz",
+      "integrity": "sha512-izzd2zmnk8Nl5ECYkW27328RbQ1nKvkm6Bb5DAaz1Gk59EbLkiCMa6OLT0NoaAYTjOFS6N+SMYW1nh4/9ljPiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.1",
+        "pathe": "^1.1.2",
+        "sirv": "^3.0.0",
+        "tinyglobby": "^0.2.10",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "2.1.9"
       }
     },
     "node_modules/@vitest/utils": {
@@ -5208,6 +5238,13 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -6882,6 +6919,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -11368,6 +11415,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/skin-tone": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
@@ -12003,6 +12065,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/traverse": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.24.3",
-        "yaml": "^2.8.2"
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "local-skills-mcp": "dist/index.js"
@@ -1068,6 +1068,18 @@
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1231,11 +1243,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
-      "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1243,13 +1256,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -3317,23 +3332,40 @@
       "license": "Apache-2.0"
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bottleneck": {
@@ -3914,15 +3946,16 @@
       "license": "ISC"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -4542,9 +4575,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5122,18 +5155,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -5164,10 +5198,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -5288,9 +5326,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -5301,7 +5339,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -5740,9 +5782,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5759,6 +5801,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hook-std": {
@@ -5795,28 +5846,23 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -5874,15 +5920,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -6011,6 +6061,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -6321,6 +6380,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6771,12 +6836,16 @@
       "license": "MIT"
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/meow": {
@@ -6851,15 +6920,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -10008,9 +10081,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -10305,12 +10378,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -10320,43 +10394,31 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -10623,26 +10685,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -11160,31 +11202,35 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -11194,6 +11240,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -11224,14 +11274,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -11243,13 +11293,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12140,17 +12190,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typedoc": {
@@ -12733,9 +12800,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -12851,21 +12918,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
-      "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
-      "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@typescript-eslint/eslint-plugin": "^8.49.0",
     "@typescript-eslint/parser": "^8.49.0",
     "@vitest/coverage-v8": "^2.1.8",
+    "@vitest/ui": "^2.1.9",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",

--- a/package.json
+++ b/package.json
@@ -86,8 +86,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.24.3",
-    "yaml": "^2.8.2"
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.2.0",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,3 +27,28 @@ npm run generate:server-json
 ## verify-links.js
 
 Verifies that links in markdown files are valid (existing script).
+
+## benchmark-shipped-skills.js / optimize-shipped-skills.js
+
+Measure and tune how reliably the bundled skills in `skills/` trigger.
+
+**Usage:**
+
+```bash
+npm run skills:benchmark-shipped:eval  # Benchmark shipped skills
+npm run skills:benchmark-shipped       # Dry-run optimization pass
+npm run skills:optimize-shipped        # Optimization pass, writing SKILL.md
+```
+
+**Eval directory layout:**
+
+| Path                 | Contents                     | Tracked in git |
+| -------------------- | ---------------------------- | -------------- |
+| `evals/<skill>.json` | Curated eval set (input)     | Yes            |
+| `evals/results/`     | Benchmark artifacts (output) | No             |
+
+Each `evals/<skill>.json` is a hand-maintained list of `{ query, should_trigger }`
+cases, named after the skill directory it covers. `eval_set_path` defaults to
+`evals/<skill_name>.json`, so a shipped skill needs a matching file here for
+`evaluate_skill` and both scripts above to run. Run artifacts land in
+`evals/results/`, which is gitignored — keep generated output out of the inputs.

--- a/scripts/benchmark-shipped-skills.js
+++ b/scripts/benchmark-shipped-skills.js
@@ -252,8 +252,11 @@ async function main() {
     "skills",
     "skill-creator"
   );
+  // Curated eval sets live in evals/*.json (tracked); run artifacts are
+  // written to evals/results/ (gitignored) so inputs stay separate from output.
   const evalDir = path.join(repoRoot, "evals");
-  fs.mkdirSync(evalDir, { recursive: true });
+  const resultsDir = path.join(evalDir, "results");
+  fs.mkdirSync(resultsDir, { recursive: true });
 
   // Resolve local-skills-mcp path only if explicitly provided via --local-skills-mcp-path.
   // By default, use command-file mode (creates .claude/commands/ files) which
@@ -401,7 +404,7 @@ async function main() {
 
   const outputPath =
     args.outputPath ||
-    path.join(evalDir, `shipped-skill-benchmark-${runId}.json`);
+    path.join(resultsDir, `shipped-skill-benchmark-${runId}.json`);
   fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
   console.log(`Saved benchmark artifact: ${outputPath}`);
 }

--- a/scripts/optimize-shipped-skills.js
+++ b/scripts/optimize-shipped-skills.js
@@ -286,8 +286,11 @@ async function main() {
 
   const startedAt = new Date().toISOString();
   const runId = new Date().toISOString().replace(/[:.]/g, "-");
+  // Curated eval sets live in evals/*.json (tracked); run artifacts are
+  // written to evals/results/ (gitignored) so inputs stay separate from output.
   const evalDir = path.join(repoRoot, "evals");
-  fs.mkdirSync(evalDir, { recursive: true });
+  const resultsDir = path.join(evalDir, "results");
+  fs.mkdirSync(resultsDir, { recursive: true });
 
   const skillReports = [];
 
@@ -494,7 +497,7 @@ async function main() {
 
   const outputPath =
     args.outputPath ||
-    path.join(evalDir, `final-skill-benchmark-${runId}.json`);
+    path.join(resultsDir, `final-skill-benchmark-${runId}.json`);
   fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
   console.log(`Saved benchmark artifact: ${outputPath}`);
 }

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -504,10 +504,11 @@ describeE2E("E2E Tests - Subprocess with Stdio Transport", () => {
         },
       });
 
-      // Should return error as tool result (skill not found)
+      // Should be rejected as an invalid name rather than resolved as a path
       expect(result.content).toBeDefined();
       expect(result.content[0].type).toBe("text");
-      expect(result.content[0].text).toContain("not found");
+      expect(result.content[0].text).toContain("Invalid skill_name");
+      expect(result.content[0].text).not.toContain("root:");
     });
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { getAllSkillsDirectories, LocalSkillsServer } from "./index.js";
+import {
+  getAllSkillsDirectories,
+  LocalSkillsServer,
+  optionalNumber,
+  optionalString,
+  requireSkillName,
+} from "./index.js";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -990,5 +996,158 @@ describe("Version handling", () => {
     expect(packageJson.version).toBeDefined();
     expect(typeof packageJson.version).toBe("string");
     expect(packageJson.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe("requireSkillName", () => {
+  it("should accept a plain skill name", () => {
+    expect(requireSkillName("code-reviewer")).toBe("code-reviewer");
+  });
+
+  it("should trim surrounding whitespace", () => {
+    expect(requireSkillName("  code-reviewer  ")).toBe("code-reviewer");
+  });
+
+  it("should reject a missing name", () => {
+    expect(() => requireSkillName(undefined)).toThrow(
+      "skill_name is required and must be a non-empty string"
+    );
+  });
+
+  it("should reject an empty or whitespace-only name", () => {
+    expect(() => requireSkillName("")).toThrow("skill_name is required");
+    expect(() => requireSkillName("   ")).toThrow("skill_name is required");
+  });
+
+  it("should reject non-string values", () => {
+    expect(() => requireSkillName(123)).toThrow("skill_name is required");
+    expect(() => requireSkillName({ skill: "x" })).toThrow(
+      "skill_name is required"
+    );
+    expect(() => requireSkillName(null)).toThrow("skill_name is required");
+  });
+
+  it("should reject POSIX path traversal", () => {
+    expect(() => requireSkillName("../../etc")).toThrow("Invalid skill_name");
+    expect(() => requireSkillName("nested/skill")).toThrow(
+      "Invalid skill_name"
+    );
+    expect(() => requireSkillName("/etc/passwd")).toThrow("Invalid skill_name");
+  });
+
+  it("should reject Windows path traversal", () => {
+    expect(() => requireSkillName("..\\..\\windows")).toThrow(
+      "Invalid skill_name"
+    );
+    expect(() => requireSkillName("nested\\skill")).toThrow(
+      "Invalid skill_name"
+    );
+  });
+
+  it("should reject relative directory references", () => {
+    expect(() => requireSkillName(".")).toThrow("Invalid skill_name");
+    expect(() => requireSkillName("..")).toThrow("Invalid skill_name");
+  });
+
+  it("should reject names containing a null byte", () => {
+    expect(() => requireSkillName("skill\0.md")).toThrow("Invalid skill_name");
+  });
+});
+
+describe("optionalString / optionalNumber", () => {
+  it("should return undefined for omitted values", () => {
+    expect(optionalString(undefined, "model")).toBeUndefined();
+    expect(optionalString(null, "model")).toBeUndefined();
+    expect(optionalNumber(undefined, "holdout")).toBeUndefined();
+    expect(optionalNumber(null, "holdout")).toBeUndefined();
+  });
+
+  it("should pass through well-typed values", () => {
+    expect(optionalString("sonnet", "model")).toBe("sonnet");
+    expect(optionalNumber(0, "holdout")).toBe(0);
+    expect(optionalNumber(0.4, "holdout")).toBe(0.4);
+  });
+
+  it("should reject wrong-typed strings", () => {
+    expect(() => optionalString(5, "model")).toThrow("model must be a string");
+  });
+
+  it("should reject wrong-typed and non-finite numbers", () => {
+    expect(() => optionalNumber("5", "holdout")).toThrow(
+      "holdout must be a finite number"
+    );
+    expect(() => optionalNumber(Number.NaN, "holdout")).toThrow(
+      "holdout must be a finite number"
+    );
+    expect(() => optionalNumber(Number.POSITIVE_INFINITY, "holdout")).toThrow(
+      "holdout must be a finite number"
+    );
+  });
+});
+
+describe("Path traversal hardening", () => {
+  let server: LocalSkillsServer | null = null;
+  let outsideDir = "";
+
+  beforeEach(() => {
+    outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "outside-skills-"));
+    const secretSkill = path.join(outsideDir, "secret");
+    fs.mkdirSync(secretSkill, { recursive: true });
+    fs.writeFileSync(
+      path.join(secretSkill, "SKILL.md"),
+      "---\nname: secret\ndescription: Should be unreachable from a configured skills directory.\n---\n\nsecret body\n"
+    );
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+    await removeDir(outsideDir);
+  });
+
+  it("should refuse to validate a SKILL.md outside the skills directories", async () => {
+    server = new LocalSkillsServer();
+    const mockServer = (server as any).server;
+    const { CallToolRequestSchema } =
+      await import("@modelcontextprotocol/sdk/types.js");
+    const callToolHandler = mockServer.handlers.get(CallToolRequestSchema);
+
+    const result = await callToolHandler({
+      params: {
+        name: "validate_skill",
+        arguments: { skill_name: `../${path.basename(outsideDir)}/secret` },
+      },
+    });
+
+    expect(result.content[0].text).toContain("Invalid skill_name");
+    expect(result.content[0].text).not.toContain("secret body");
+  });
+
+  it("should refuse to evaluate a skill outside the skills directories", async () => {
+    server = new LocalSkillsServer();
+    const mockServer = (server as any).server;
+    const { CallToolRequestSchema } =
+      await import("@modelcontextprotocol/sdk/types.js");
+    const callToolHandler = mockServer.handlers.get(CallToolRequestSchema);
+
+    const result = await callToolHandler({
+      params: {
+        name: "evaluate_skill",
+        arguments: { skill_name: "../../../../tmp" },
+      },
+    });
+
+    expect(result.content[0].text).toContain("Invalid skill_name");
+  });
+
+  it("should not resolve a skill directory that escapes its base directory", () => {
+    server = new LocalSkillsServer();
+    const resolve = (server as any).resolveSkillFilePath.bind(server);
+
+    // Bypasses requireSkillName to exercise the containment check directly.
+    expect(resolve(`../${path.basename(outsideDir)}/secret`)).toBeNull();
+    expect(resolve("..")).toBeNull();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1125,6 +1125,41 @@ describe("Path traversal hardening", () => {
     expect(result.content[0].text).not.toContain("secret body");
   });
 
+  // Symlink creation needs elevated privileges on Windows.
+  it.skipIf(process.platform === "win32")(
+    "should still serve a skill whose SKILL.md is a symlink into another repo",
+    async () => {
+      // Managing skills in a dotfiles repo and symlinking them into
+      // ~/.claude/skills is a common setup; the file is a link but the skill
+      // directory is real, so discovery finds it and validation must too.
+      const skillsDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "linked-skills-")
+      );
+      try {
+        const skillDir = path.join(skillsDir, "linked");
+        fs.mkdirSync(skillDir);
+        fs.symlinkSync(
+          path.join(outsideDir, "secret", "SKILL.md"),
+          path.join(skillDir, "SKILL.md")
+        );
+
+        const { SkillLoader } = await import("./skill-loader.js");
+        const loader = new SkillLoader([skillsDir]);
+
+        const location = await loader.getSkillLocation("linked");
+        expect(location.path).toBe(skillDir);
+      } finally {
+        fs.rmSync(skillsDir, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it("should treat an encoded separator as a literal name, not a traversal", () => {
+    // %2f is not a path separator at the filesystem layer, so this is just an
+    // unusual name — the registry simply has no such key.
+    expect(() => requireSkillName("..%2f..%2fsecret")).not.toThrow();
+  });
+
   it("should refuse to evaluate a skill outside the skills directories", async () => {
     server = new LocalSkillsServer();
     const mockServer = (server as any).server;
@@ -1141,13 +1176,89 @@ describe("Path traversal hardening", () => {
 
     expect(result.content[0].text).toContain("Invalid skill_name");
   });
+});
 
-  it("should not resolve a skill directory that escapes its base directory", () => {
+describe("get_skill name round-trip", () => {
+  let server: LocalSkillsServer | null = null;
+  let skillsDir = "";
+  const originalHomedir = os.homedir;
+  const originalSkillsDir = process.env.SKILLS_DIR;
+
+  beforeEach(() => {
+    skillsDir = fs.mkdtempSync(path.join(os.tmpdir(), "roundtrip-skills-"));
+    const skillPath = path.join(skillsDir, "session-start-hook");
+    fs.mkdirSync(skillPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillPath, "SKILL.md"),
+      "---\nname: startup-hook-skill\ndescription: Directory name and frontmatter name deliberately disagree.\n---\n\nhook body\n"
+    );
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+    (os as any).homedir = originalHomedir;
+    process.env.SKILLS_DIR = originalSkillsDir;
+    await removeDir(skillsDir);
+  });
+
+  it("should return a name the caller can pass straight back to get_skill", async () => {
+    const { SkillLoader } = await import("./skill-loader.js");
     server = new LocalSkillsServer();
-    const resolve = (server as any).resolveSkillFilePath.bind(server);
+    // Point the server's loader at the fixture so the assertion does not
+    // depend on whatever skills the developer happens to have installed.
+    (server as any).skillLoader = new SkillLoader([skillsDir]);
 
-    // Bypasses requireSkillName to exercise the containment check directly.
-    expect(resolve(`../${path.basename(outsideDir)}/secret`)).toBeNull();
-    expect(resolve("..")).toBeNull();
+    const mockServer = (server as any).server;
+    const { CallToolRequestSchema } =
+      await import("@modelcontextprotocol/sdk/types.js");
+    const callToolHandler = mockServer.handlers.get(CallToolRequestSchema);
+
+    const first = await callToolHandler({
+      params: {
+        name: "get_skill",
+        arguments: { skill_name: "session-start-hook" },
+      },
+    });
+
+    const header = (first.content[0].text as string).split("\n")[0];
+    expect(header).toBe("# Skill: session-start-hook");
+    expect(first.content[0].text).toContain("**Title:** startup-hook-skill");
+
+    // Feed the returned name back in; it must resolve to the same skill.
+    const returnedName = header.replace("# Skill: ", "").trim();
+    const second = await callToolHandler({
+      params: { name: "get_skill", arguments: { skill_name: returnedName } },
+    });
+
+    expect(second.content[0].text).toBe(first.content[0].text);
+    expect(second.content[0].text).not.toContain("not found");
+  });
+
+  it("should omit the title line when it matches the directory name", async () => {
+    const matching = path.join(skillsDir, "plain-skill");
+    fs.mkdirSync(matching, { recursive: true });
+    fs.writeFileSync(
+      path.join(matching, "SKILL.md"),
+      "---\nname: plain-skill\ndescription: Directory name and frontmatter name agree here.\n---\n\nbody\n"
+    );
+
+    const { SkillLoader } = await import("./skill-loader.js");
+    server = new LocalSkillsServer();
+    (server as any).skillLoader = new SkillLoader([skillsDir]);
+
+    const mockServer = (server as any).server;
+    const { CallToolRequestSchema } =
+      await import("@modelcontextprotocol/sdk/types.js");
+    const callToolHandler = mockServer.handlers.get(CallToolRequestSchema);
+
+    const result = await callToolHandler({
+      params: { name: "get_skill", arguments: { skill_name: "plain-skill" } },
+    });
+
+    expect(result.content[0].text).toContain("# Skill: plain-skill");
+    expect(result.content[0].text).not.toContain("**Title:**");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,88 @@ export function getAllSkillsDirectories(): string[] {
   return directories;
 }
 
+/**
+ * Validate and normalize a `skill_name` tool argument.
+ *
+ * Tool arguments arrive untyped over the wire, so the name is checked here
+ * before it is ever used to build a filesystem path. Path separators are
+ * rejected outright: a skill name always identifies a single directory inside
+ * a configured skills directory, never a path into one.
+ *
+ * @param value - The raw `skill_name` argument from the tool call
+ * @returns The trimmed skill name
+ * @throws {Error} If the value is missing, not a string, or not a plain name
+ *
+ * @example
+ * ```typescript
+ * requireSkillName("code-reviewer"); // 'code-reviewer'
+ * requireSkillName("../../etc");     // throws
+ * ```
+ */
+export function requireSkillName(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("skill_name is required and must be a non-empty string");
+  }
+
+  const skillName = value.trim();
+
+  if (
+    skillName.includes("/") ||
+    skillName.includes("\\") ||
+    skillName.includes("\0") ||
+    skillName === "." ||
+    skillName === ".."
+  ) {
+    throw new Error(
+      `Invalid skill_name "${skillName}". A skill name is a single directory name, not a path.`
+    );
+  }
+
+  return skillName;
+}
+
+/**
+ * Read an optional string tool argument, rejecting wrong-typed values.
+ *
+ * @param value - The raw argument value
+ * @param field - Argument name, used in the error message
+ * @returns The string, or undefined when the argument was omitted
+ * @throws {Error} If the value is present but not a string
+ */
+export function optionalString(
+  value: unknown,
+  field: string
+): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a string`);
+  }
+  return value;
+}
+
+/**
+ * Read an optional numeric tool argument, rejecting wrong-typed values.
+ *
+ * @param value - The raw argument value
+ * @param field - Argument name, used in the error message
+ * @returns The number, or undefined when the argument was omitted
+ * @throws {Error} If the value is present but not a finite number
+ */
+export function optionalNumber(
+  value: unknown,
+  field: string
+): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${field} must be a finite number`);
+  }
+  return value;
+}
+
 const SKILLS_DIRS = getAllSkillsDirectories();
 
 /**
@@ -309,7 +391,17 @@ export class LocalSkillsServer {
 
   private resolveSkillFilePath(skillName: string): string | null {
     for (let i = SKILLS_DIRS.length - 1; i >= 0; i--) {
-      const candidate = path.join(SKILLS_DIRS[i], skillName, "SKILL.md");
+      const baseDir = path.resolve(SKILLS_DIRS[i]);
+      const skillDir = path.resolve(baseDir, skillName);
+
+      // Only accept paths that stay strictly inside the configured directory.
+      // Without this, a skill_name such as "../../etc" would let a caller
+      // reach SKILL.md files outside every configured skills directory.
+      if (!skillDir.startsWith(baseDir + path.sep)) {
+        continue;
+      }
+
+      const candidate = path.join(skillDir, "SKILL.md");
       if (fs.existsSync(candidate)) {
         return candidate;
       }
@@ -317,15 +409,10 @@ export class LocalSkillsServer {
     return null;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async handleValidateSkill(args: any) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const skillName = args?.skill_name;
-    if (!skillName) {
-      throw new Error("skill_name is required");
-    }
+  private async handleValidateSkill(args: Record<string, unknown> | undefined) {
+    const skillName = requireSkillName(args?.skill_name);
 
-    const skillFilePath = this.resolveSkillFilePath(skillName as string);
+    const skillFilePath = this.resolveSkillFilePath(skillName);
     if (!skillFilePath) {
       throw new Error(`Skill "${skillName}" not found.`);
     }
@@ -342,42 +429,36 @@ export class LocalSkillsServer {
     };
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async handleEvaluateSkill(args: any) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const skillName = args?.skill_name;
-    if (!skillName) {
-      throw new Error("skill_name is required");
-    }
+  private async handleEvaluateSkill(args: Record<string, unknown> | undefined) {
+    const skillName = requireSkillName(args?.skill_name);
 
-    const skillFilePath = this.resolveSkillFilePath(skillName as string);
+    const skillFilePath = this.resolveSkillFilePath(skillName);
     if (!skillFilePath) {
       throw new Error(`Skill "${skillName}" not found.`);
     }
 
     const result = await evaluateSkill(
       {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         skill_name: skillName,
         skill_path: path.dirname(skillFilePath),
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        eval_set_path: args?.eval_set_path,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        max_iterations: args?.max_iterations,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        num_workers: args?.num_workers,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        runs_per_query: args?.runs_per_query,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        timeout_seconds: args?.timeout_seconds,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        holdout: args?.holdout,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        trigger_threshold: args?.trigger_threshold,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        description_override: args?.description_override,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        model: args?.model,
+        eval_set_path: optionalString(args?.eval_set_path, "eval_set_path"),
+        max_iterations: optionalNumber(args?.max_iterations, "max_iterations"),
+        num_workers: optionalNumber(args?.num_workers, "num_workers"),
+        runs_per_query: optionalNumber(args?.runs_per_query, "runs_per_query"),
+        timeout_seconds: optionalNumber(
+          args?.timeout_seconds,
+          "timeout_seconds"
+        ),
+        holdout: optionalNumber(args?.holdout, "holdout"),
+        trigger_threshold: optionalNumber(
+          args?.trigger_threshold,
+          "trigger_threshold"
+        ),
+        description_override: optionalString(
+          args?.description_override,
+          "description_override"
+        ),
+        model: optionalString(args?.model, "model"),
       },
       REPO_ROOT
     );
@@ -392,15 +473,9 @@ export class LocalSkillsServer {
     };
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async handleGetSkill(args: any) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const skillName = args?.skill_name;
-    if (!skillName) {
-      throw new Error("skill_name is required");
-    }
+  private async handleGetSkill(args: Record<string, unknown> | undefined) {
+    const skillName = requireSkillName(args?.skill_name);
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const skill = await this.skillLoader.loadSkill(skillName);
 
     const output = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,14 +191,26 @@ const SKILLS_DIRS = getAllSkillsDirectories();
 export class LocalSkillsServer {
   private server: Server;
   private skillLoader: SkillLoader;
+  private skillsDirs: string[];
 
   /**
    * Creates a new LocalSkillsServer instance.
    *
    * Initializes the MCP server with capabilities, creates a SkillLoader
-   * for all configured directories, and sets up request handlers.
+   * for the given directories, and sets up request handlers.
+   *
+   * @param skillsDirs - Directories to serve skills from. Defaults to the
+   *   directories discovered at startup by {@link getAllSkillsDirectories}.
+   *   Pass an explicit list to serve a fixed set — tests use this to stay
+   *   independent of whatever the host machine has in `~/.claude/skills`.
+   *
+   * @example
+   * ```typescript
+   * const server = new LocalSkillsServer();                 // default locations
+   * const scoped = new LocalSkillsServer(['/tmp/fixtures']); // only these
+   * ```
    */
-  constructor() {
+  constructor(skillsDirs: string[] = SKILLS_DIRS) {
     this.server = new Server(
       {
         name: "local-skills-mcp",
@@ -212,7 +224,8 @@ export class LocalSkillsServer {
       }
     );
 
-    this.skillLoader = new SkillLoader(SKILLS_DIRS);
+    this.skillsDirs = skillsDirs;
+    this.skillLoader = new SkillLoader(skillsDirs);
 
     this.setupHandlers();
     this.setupErrorHandling();
@@ -263,6 +276,14 @@ export class LocalSkillsServer {
           }
         }
         getSkillDescription += `\n\nAvailable skills:\n${skillsWithDescriptions.join("\n")}`;
+      } else {
+        // Say so plainly rather than advertising expertise that is not there,
+        // and name the directories that were searched so the gap is fixable.
+        const searched =
+          this.skillsDirs.length > 0
+            ? this.skillsDirs.map((dir) => `- ${dir}`).join("\n")
+            : "- (none configured)";
+        getSkillDescription += `\n\nNo skills currently available. Check configured directories:\n${searched}`;
       }
 
       const tools: Tool[] = [
@@ -389,35 +410,15 @@ export class LocalSkillsServer {
     });
   }
 
-  private resolveSkillFilePath(skillName: string): string | null {
-    for (let i = SKILLS_DIRS.length - 1; i >= 0; i--) {
-      const baseDir = path.resolve(SKILLS_DIRS[i]);
-      const skillDir = path.resolve(baseDir, skillName);
-
-      // Only accept paths that stay strictly inside the configured directory.
-      // Without this, a skill_name such as "../../etc" would let a caller
-      // reach SKILL.md files outside every configured skills directory.
-      if (!skillDir.startsWith(baseDir + path.sep)) {
-        continue;
-      }
-
-      const candidate = path.join(skillDir, "SKILL.md");
-      if (fs.existsSync(candidate)) {
-        return candidate;
-      }
-    }
-    return null;
-  }
-
   private async handleValidateSkill(args: Record<string, unknown> | undefined) {
     const skillName = requireSkillName(args?.skill_name);
 
-    const skillFilePath = this.resolveSkillFilePath(skillName);
-    if (!skillFilePath) {
-      throw new Error(`Skill "${skillName}" not found.`);
-    }
-
-    const result = await validateSkillFile(skillFilePath);
+    // Resolve through the registry, exactly as get_skill does, so a name can
+    // only reach a skill directory that discovery actually found.
+    const location = await this.skillLoader.getSkillLocation(skillName);
+    const result = await validateSkillFile(
+      path.join(location.path, "SKILL.md")
+    );
 
     return {
       content: [
@@ -432,15 +433,12 @@ export class LocalSkillsServer {
   private async handleEvaluateSkill(args: Record<string, unknown> | undefined) {
     const skillName = requireSkillName(args?.skill_name);
 
-    const skillFilePath = this.resolveSkillFilePath(skillName);
-    if (!skillFilePath) {
-      throw new Error(`Skill "${skillName}" not found.`);
-    }
+    const location = await this.skillLoader.getSkillLocation(skillName);
 
     const result = await evaluateSkill(
       {
         skill_name: skillName,
-        skill_path: path.dirname(skillFilePath),
+        skill_path: location.path,
         eval_set_path: optionalString(args?.eval_set_path, "eval_set_path"),
         max_iterations: optionalNumber(args?.max_iterations, "max_iterations"),
         num_workers: optionalNumber(args?.num_workers, "num_workers"),
@@ -478,9 +476,13 @@ export class LocalSkillsServer {
 
     const skill = await this.skillLoader.loadSkill(skillName);
 
+    // The header carries skill.name (the directory name), which is the value
+    // that can be passed straight back to get_skill. The frontmatter name is
+    // shown separately, and only when it says something different.
     const output = [
       `# Skill: ${skill.name}`,
       ``,
+      ...(skill.title !== skill.name ? [`**Title:** ${skill.title}`] : []),
       `**Description:** ${skill.description}`,
       `**Source:** ${skill.source}`,
       ``,
@@ -525,9 +527,9 @@ export class LocalSkillsServer {
     await this.server.connect(transport);
     console.error(`Local Skills MCP Server v${VERSION} running on stdio`);
     console.error(
-      `Aggregating skills from ${SKILLS_DIRS.length} director${SKILLS_DIRS.length === 1 ? "y" : "ies"}:`
+      `Aggregating skills from ${this.skillsDirs.length} director${this.skillsDirs.length === 1 ? "y" : "ies"}:`
     );
-    SKILLS_DIRS.forEach((dir) => console.error(`  - ${dir}`));
+    this.skillsDirs.forEach((dir) => console.error(`  - ${dir}`));
   }
 
   /**

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -365,9 +365,12 @@ This skill's directory name is not its frontmatter name.`
       });
 
       const text = (response.content as any[])[0].text;
-      expect(text).toContain("**Source:**");
-      // Should contain some path
-      expect(text).toMatch(/\/.*skills/);
+      // Now that the suite serves a known directory, assert the actual value.
+      // The previous `/\/.*skills/` regex matched anywhere in the response and
+      // was in practice satisfied by forward slashes in the shipped skills'
+      // prose rather than by the source path, so it passed on Windows for the
+      // wrong reason and said nothing about the Source line.
+      expect(text).toContain(`**Source:** ${skillsDir}`);
     });
   });
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -100,14 +100,34 @@ This is the content of test skill 2.
 It provides different guidance.`
     );
 
-    // Change to temp directory so server discovers our test skills
+    // A skill whose directory name and frontmatter name deliberately disagree,
+    // so the suite exercises the name round-trip rather than assuming they match.
+    const skill3Dir = path.join(skillsDir, "session-start-hook");
+    fs.mkdirSync(skill3Dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skill3Dir, "SKILL.md"),
+      `---
+name: startup-hook-skill
+description: Third test skill whose directory and frontmatter names disagree
+---
+
+# Startup Hook Skill
+
+This skill's directory name is not its frontmatter name.`
+    );
+
+    // chdir is kept so cwd-relative behaviour matches production, but it does
+    // not steer discovery: the server is given its directories explicitly below.
     process.chdir(tempDir);
 
     // Create in-memory transport pair
     [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
-    // Create server
-    server = new LocalSkillsServer();
+    // Serve only the fixtures. Without this the server would resolve its
+    // directories at import time and pick up the host's ~/.claude/skills,
+    // making results depend on whatever the developer happens to have
+    // installed — which is how the get_skill name round-trip bug stayed hidden.
+    server = new LocalSkillsServer([skillsDir]);
 
     // Create client
     client = new Client(
@@ -506,7 +526,7 @@ It provides different guidance.`
           InMemoryTransport.createLinkedPair();
 
         // Create server in empty directory
-        const emptyServer = new LocalSkillsServer();
+        const emptyServer = new LocalSkillsServer([emptySkillsDir]);
         const emptyClient = new Client(
           { name: "empty-test-client", version: "1.0.0" },
           { capabilities: {} }

--- a/src/skill-loader.test.ts
+++ b/src/skill-loader.test.ts
@@ -460,4 +460,74 @@ This is the content that should not be loaded`
       expect(loader.getSkillsPaths()).toEqual(paths);
     });
   });
+
+  describe("lazy registry resolution", () => {
+    async function writeSkill(dir: string, name: string, description: string) {
+      const skillPath = path.join(dir, name);
+      await fs.mkdir(skillPath, { recursive: true });
+      await fs.writeFile(
+        path.join(skillPath, "SKILL.md"),
+        `---\nname: ${name}\ndescription: ${description}\n---\n\n${name} body\n`
+      );
+    }
+
+    it("should load a skill without a prior discoverSkills() call", async () => {
+      await writeSkill(tempDir, "cold-start", "Loaded without listing first");
+      skillLoader = new SkillLoader([tempDir]);
+
+      // No discoverSkills() here: MCP clients may call a tool without
+      // first listing tools, e.g. when reusing a cached tool list.
+      const skill = await skillLoader.loadSkill("cold-start");
+
+      expect(skill.name).toBe("cold-start");
+      expect(skill.content).toContain("cold-start body");
+    });
+
+    it("should read metadata without a prior discoverSkills() call", async () => {
+      await writeSkill(tempDir, "cold-meta", "Metadata without listing first");
+      skillLoader = new SkillLoader([tempDir]);
+
+      const metadata = await skillLoader.getSkillMetadata("cold-meta");
+
+      expect(metadata.name).toBe("cold-meta");
+      expect(metadata.source).toBe(tempDir);
+    });
+
+    it("should pick up a skill added after the last discovery", async () => {
+      await writeSkill(tempDir, "first", "Present at discovery time");
+      skillLoader = new SkillLoader([tempDir]);
+      await skillLoader.discoverSkills();
+
+      await writeSkill(tempDir, "second", "Added after discovery");
+
+      const skill = await skillLoader.loadSkill("second");
+      expect(skill.name).toBe("second");
+    });
+
+    it("should list available skills in the not-found error", async () => {
+      await writeSkill(tempDir, "alpha", "First available skill");
+      await writeSkill(tempDir, "beta", "Second available skill");
+      skillLoader = new SkillLoader([tempDir]);
+
+      await expect(skillLoader.loadSkill("gamma")).rejects.toThrow(
+        'Skill "gamma" not found. Available skills: alpha, beta'
+      );
+    });
+
+    it("should report the searched directories when nothing was discovered", async () => {
+      skillLoader = new SkillLoader([tempDir]);
+
+      await expect(skillLoader.loadSkill("anything")).rejects.toThrow(
+        `No skills were discovered in: ${tempDir}`
+      );
+    });
+
+    it("should report a missing configuration when no directories are set", async () => {
+      skillLoader = new SkillLoader([]);
+
+      await expect(skillLoader.loadSkill("anything")).rejects.toThrow(
+        "(no directories configured)"
+      );
+    });
+  });
 });

--- a/src/skill-loader.test.ts
+++ b/src/skill-loader.test.ts
@@ -530,4 +530,48 @@ This is the content that should not be loaded`
       );
     });
   });
+
+  describe("name round-trip", () => {
+    // The registry is keyed on directory name, so that is the only name a
+    // caller can feed back in. Returning the frontmatter name instead handed
+    // callers the one value that provably cannot fetch the skill again.
+    async function writeMismatchedSkill(dir: string) {
+      const skillPath = path.join(dir, "session-start-hook");
+      await fs.mkdir(skillPath, { recursive: true });
+      await fs.writeFile(
+        path.join(skillPath, "SKILL.md"),
+        "---\nname: startup-hook-skill\ndescription: Directory name and frontmatter name deliberately disagree.\n---\n\nhook body\n"
+      );
+    }
+
+    it("should return the directory name as the skill identity", async () => {
+      await writeMismatchedSkill(tempDir);
+      skillLoader = new SkillLoader([tempDir]);
+
+      const skill = await skillLoader.loadSkill("session-start-hook");
+
+      expect(skill.name).toBe("session-start-hook");
+      expect(skill.title).toBe("startup-hook-skill");
+    });
+
+    it("should let the returned name fetch the same skill again", async () => {
+      await writeMismatchedSkill(tempDir);
+      skillLoader = new SkillLoader([tempDir]);
+
+      const first = await skillLoader.loadSkill("session-start-hook");
+      const second = await skillLoader.loadSkill(first.name);
+
+      expect(second).toStrictEqual(first);
+    });
+
+    it("should list the directory name in discovery", async () => {
+      await writeMismatchedSkill(tempDir);
+      skillLoader = new SkillLoader([tempDir]);
+
+      const names = await skillLoader.discoverSkills();
+
+      expect(names).toContain("session-start-hook");
+      expect(names).not.toContain("startup-hook-skill");
+    });
+  });
 });

--- a/src/skill-loader.ts
+++ b/src/skill-loader.ts
@@ -200,7 +200,8 @@ export class SkillLoader {
    * @example
    * ```typescript
    * const skill = await loader.loadSkill('code-reviewer');
-   * console.log(skill.name);        // 'Code Reviewer'
+   * console.log(skill.name);        // 'code-reviewer' (directory name, round-trips)
+   * console.log(skill.title);       // 'Code Reviewer' (frontmatter name)
    * console.log(skill.description); // 'Expert code review assistant'
    * console.log(skill.content);     // Full skill prompt content
    * console.log(skill.source);      // '/home/user/.claude/skills'
@@ -231,7 +232,10 @@ export class SkillLoader {
       const { metadata, content } = this.parseSkillFile(fileContent);
 
       const skill: Skill = {
-        name: metadata.name,
+        // The registry is keyed on directory name, so that is the identity a
+        // caller can feed back to get_skill. The frontmatter name is a label.
+        name: skillName,
+        title: metadata.name,
         description: metadata.description,
         content,
         path: skillInfo.path,
@@ -284,6 +288,32 @@ export class SkillLoader {
         `Failed to load metadata for skill "${skillName}": ${(error as Error).message}`
       );
     }
+  }
+
+  /**
+   * Resolve a skill's on-disk location without reading or parsing its file.
+   *
+   * Uses the same registry lookup as {@link loadSkill}, so a name can only ever
+   * resolve to a directory that discovery actually found. Callers that need to
+   * inspect a `SKILL.md` which may not parse — validation, for instance — can
+   * use this instead of {@link loadSkill}, which would throw on malformed
+   * frontmatter before they get the chance.
+   *
+   * @param skillName - The name of the skill to locate
+   * @returns The skill's directory and the skills directory it came from
+   * @throws {Error} If the skill is not found after a registry refresh
+   *
+   * @example
+   * ```typescript
+   * const { path, source } = await loader.getSkillLocation('code-reviewer');
+   * // path:   '/home/user/.claude/skills/code-reviewer'
+   * // source: '/home/user/.claude/skills'
+   * ```
+   */
+  async getSkillLocation(
+    skillName: string
+  ): Promise<{ path: string; source: string }> {
+    return this.resolveSkillInfo(skillName);
   }
 
   /**

--- a/src/skill-loader.ts
+++ b/src/skill-loader.ts
@@ -81,6 +81,54 @@ export class SkillLoader {
   }
 
   /**
+   * Resolve a skill's location, refreshing the registry when the name is unknown.
+   *
+   * The registry is only populated by {@link discoverSkills}. MCP clients are
+   * free to call a tool without first listing tools (or may hold a cached tool
+   * list across a restart), so an unknown name triggers a rescan before the
+   * lookup is treated as a genuine miss. This also picks up skills added to
+   * disk since the last scan.
+   *
+   * @param skillName - The name of the skill to locate
+   * @returns The registry entry for the skill
+   * @throws {Error} If the skill cannot be found after a refresh
+   */
+  private async resolveSkillInfo(
+    skillName: string
+  ): Promise<{ path: string; source: string }> {
+    let skillInfo = this.skillRegistry.get(skillName);
+    if (!skillInfo) {
+      await this.discoverSkills();
+      skillInfo = this.skillRegistry.get(skillName);
+    }
+
+    if (!skillInfo) {
+      throw new Error(
+        `Skill "${skillName}" not found. ${this.describeAvailableSkills()}`
+      );
+    }
+
+    return skillInfo;
+  }
+
+  /**
+   * Build a human-readable hint listing what is currently available.
+   */
+  private describeAvailableSkills(): string {
+    const available = Array.from(this.skillRegistry.keys()).sort();
+    if (available.length === 0) {
+      return `No skills were discovered in: ${this.skillsPaths.join(", ") || "(no directories configured)"}`;
+    }
+
+    const MAX_LISTED = 25;
+    const listed = available.slice(0, MAX_LISTED).join(", ");
+    const remainder = available.length - MAX_LISTED;
+    return remainder > 0
+      ? `Available skills: ${listed} (and ${remainder} more)`
+      : `Available skills: ${listed}`;
+  }
+
+  /**
    * Discover all available skills aggregated from all directories.
    *
    * Scans all configured directories for subdirectories containing SKILL.md files.
@@ -165,18 +213,15 @@ export class SkillLoader {
    *   const skill = await loader.loadSkill('non-existent');
    * } catch (error) {
    *   console.error(error.message);
-   *   // "Skill "non-existent" not found. Run list_skills to see available skills."
+   *   // "Skill "non-existent" not found. Available skills: code-reviewer, test-generator"
    * }
    * ```
    */
   async loadSkill(skillName: string): Promise<Skill> {
-    // Get skill location from registry
-    const skillInfo = this.skillRegistry.get(skillName);
-    if (!skillInfo) {
-      throw new Error(
-        `Skill "${skillName}" not found. Run list_skills to see available skills.`
-      );
-    }
+    // Get skill location from registry, refreshing it if the name is unknown.
+    // The registry is empty until discoverSkills() runs, and clients are not
+    // required to call tools/list before tools/call, so resolve lazily here.
+    const skillInfo = await this.resolveSkillInfo(skillName);
 
     const skillFilePath = path.join(skillInfo.path, "SKILL.md");
 
@@ -223,10 +268,7 @@ export class SkillLoader {
   async getSkillMetadata(
     skillName: string
   ): Promise<SkillMetadata & { source: string }> {
-    const skillInfo = this.skillRegistry.get(skillName);
-    if (!skillInfo) {
-      throw new Error(`Skill "${skillName}" not found`);
-    }
+    const skillInfo = await this.resolveSkillInfo(skillName);
 
     const skillFilePath = path.join(skillInfo.path, "SKILL.md");
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -36,6 +36,7 @@ describe("types", () => {
     it("should allow valid skill objects", () => {
       const skill: Skill = {
         name: "code-reviewer",
+        title: "code-reviewer",
         description: "Reviews code for best practices",
         content: "Detailed skill instructions...",
         path: "/home/user/.claude/skills/code-reviewer",
@@ -52,6 +53,7 @@ describe("types", () => {
     it("should extend SkillMetadata with additional fields", () => {
       const skill: Skill = {
         name: "test",
+        title: "test",
         description: "test description",
         content: "content",
         path: "/path",
@@ -76,6 +78,7 @@ describe("types", () => {
     it("should support all required fields", () => {
       const skill: Skill = {
         name: "minimal-skill",
+        title: "minimal-skill",
         description: "minimal description",
         content: "",
         path: "",
@@ -106,6 +109,7 @@ const example = "code";
 
       const skill: Skill = {
         name: "complex-skill",
+        title: "complex-skill",
         description: "A skill with complex content",
         content: complexContent,
         path: "/skills/complex",
@@ -120,6 +124,7 @@ const example = "code";
     it("should handle special characters in paths", () => {
       const skill: Skill = {
         name: "special-path-skill",
+        title: "special-path-skill",
         description: "Skill with special path characters",
         content: "content",
         path: "/home/user/.claude/skills/my-skill",
@@ -136,6 +141,7 @@ const example = "code";
     it("should allow assigning SkillMetadata from Skill", () => {
       const skill: Skill = {
         name: "test-skill",
+        title: "test-skill",
         description: "test description",
         content: "content",
         path: "/path",
@@ -153,6 +159,7 @@ const example = "code";
       const skills: Skill[] = [
         {
           name: "skill1",
+          title: "skill1",
           description: "First skill",
           content: "content1",
           path: "/path1",
@@ -160,6 +167,7 @@ const example = "code";
         },
         {
           name: "skill2",
+          title: "skill2",
           description: "Second skill",
           content: "content2",
           path: "/path2",
@@ -180,6 +188,7 @@ const example = "code";
 
       const skill: Skill = {
         name: "mapped-skill",
+        title: "mapped-skill",
         description: "Skill in map",
         content: "content",
         path: "/path",

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,8 @@ export interface SkillMetadata {
  * Full skill definition including prompt content
  */
 export interface Skill {
-  name: string;
+  name: string; // Directory name — the key that get_skill accepts
+  title: string; // Display name from YAML frontmatter, may differ from name
   description: string;
   content: string;
   path: string;

--- a/typedoc.json
+++ b/typedoc.json
@@ -26,19 +26,8 @@
     "Type alias"
   ],
   "categorizeByGroup": true,
-  "categoryOrder": [
-    "Core Classes",
-    "Interfaces",
-    "Functions",
-    "*"
-  ],
-  "groupOrder": [
-    "Classes",
-    "Interfaces",
-    "Type Aliases",
-    "Functions",
-    "*"
-  ],
+  "categoryOrder": ["Core Classes", "Interfaces", "Functions", "*"],
+  "groupOrder": ["Classes", "Interfaces", "Type Aliases", "Functions", "*"],
   "visibilityFilters": {
     "protected": false,
     "private": false,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    // The e2e suite spawns the compiled server, so ensure dist/ is built and
+    // current before any test runs.
+    globalSetup: ["./vitest.global-setup.ts"],
     testTimeout: 60000, // 60 seconds for e2e tests on slower CI environments
     hookTimeout: 60000, // 60 seconds for setup/teardown hooks on slower CI environments
     coverage: {

--- a/vitest.global-setup.ts
+++ b/vitest.global-setup.ts
@@ -1,0 +1,64 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+const srcDir = path.join(projectRoot, "src");
+const distEntry = path.join(projectRoot, "dist", "index.js");
+const tscBin = path.join(
+  projectRoot,
+  "node_modules",
+  "typescript",
+  "bin",
+  "tsc"
+);
+
+/**
+ * Most recent modification time under a directory, in milliseconds.
+ */
+function newestMtimeMs(dir: string): number {
+  let newest = 0;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    const mtime = entry.isDirectory()
+      ? newestMtimeMs(entryPath)
+      : fs.statSync(entryPath).mtimeMs;
+
+    if (mtime > newest) {
+      newest = mtime;
+    }
+  }
+
+  return newest;
+}
+
+/**
+ * Build the project when `dist/` is missing or older than `src/`.
+ *
+ * The e2e suite spawns `dist/index.js` as a real subprocess, so the compiled
+ * output is a test prerequisite. Building here keeps every entry point
+ * (`npm test`, `test:run`, `test:e2e`, `test:coverage`) working on a fresh
+ * clone instead of failing with an opaque "Server exited with code 1".
+ */
+export default function setup(): void {
+  const distExists = fs.existsSync(distEntry);
+  const isStale =
+    distExists && newestMtimeMs(srcDir) > fs.statSync(distEntry).mtimeMs;
+
+  if (distExists && !isStale) {
+    return;
+  }
+
+  console.log(
+    distExists
+      ? "[vitest] dist/ is older than src/ — rebuilding before tests..."
+      : "[vitest] dist/ not found — building before tests..."
+  );
+
+  execFileSync(process.execPath, [tscBin], {
+    cwd: projectRoot,
+    stdio: "inherit",
+  });
+}


### PR DESCRIPTION
Works through the agent-assignable `local-skills-mcp` items from the 2026-08-17 remediation brief, plus repo-health issues found while verifying them. Every bug here was reproduced by driving the built server over stdio before being fixed, and re-verified the same way after.

`main` was green throughout — none of these were visible to CI.

## Security & correctness

**LSM-1 — `skill_name` path traversal** (`fix:`)

`validate_skill` and `evaluate_skill` built a filesystem path straight from the untrusted `skill_name` argument. Reproduced live:

```
validate_skill({ skill_name: '../outside/secret' })
  → { "valid": true, "errors": [], "warnings": [...] }
```

`evaluate_skill` used the same resolver and then handed the resulting directory to a spawned Python process.

Both handlers now resolve through the same registry `get_skill` uses, as the brief preferred: one lookup path, and a name can only ever reach a directory that discovery actually found. `skill_name` is additionally validated as a single directory name (no separators, null bytes, `.` or `..`).

A first pass used a `realpath` containment check instead. That was dropped: it broke the common pattern of symlinking `SKILL.md` from a dotfiles repo into `~/.claude/skills` — which this machine turned out to use, so the regression surfaced immediately. Verified after the change that traversal and symlinked skill *directories* are refused, while a symlinked `SKILL.md` inside a real skill directory still works.

**LSM-2 — `get_skill` returned a name that could not fetch the skill** (`fix:`)

The registry is keyed on directory name; the response carried the frontmatter `name:`. Where they disagree, the caller got back the one name that provably cannot be used again:

```
get_skill('session-start-hook') → "# Skill: startup-hook-skill"
get_skill('startup-hook-skill') → Error: not found
```

`Skill.name` is now the directory name; the frontmatter name moves to a new `Skill.title`, surfaced as a `**Title:**` line only when it differs.

**Cold-start lookup failure** (`fix:`)

`get_skill` failed with "not found" whenever a client called a tool without first calling `tools/list` — the registry is only populated by `discoverSkills()`. Clients aren't required to list first and may reuse a cached tool list. An unknown name now triggers a rescan before it's treated as a miss, which also picks up skills added since the last scan.

The not-found error also pointed at `list_skills`, a tool removed in 0.2.0. It now names the skills actually discovered, or the directories searched when there were none.

## Tests

**LSM-3 — integration suite wasn't hermetic** (`test:`)

The suite called `process.chdir()` to point discovery at its fixtures, but `SKILLS_DIRS` resolves at import time, so chdir never affected it — the suite silently ran against the developer's real `~/.claude/skills`. That is why LSM-2 survived a green CI: the shipped skills all have matching names.

`LocalSkillsServer` now takes its directories as an optional constructor argument and the suite passes fixtures explicitly, including one with deliberately disagreeing names. Verified identical results (19 passed) with a populated and an empty `HOME`, as the brief asked.

Scoping the suite also exposed that `"No skills currently available. Check configured directories:"` was asserted by four tests but never implemented — the empty case only ever passed through an `|| includes("Available skills")` escape hatch fed by leaked real skills. Implemented, and it now lists the directories searched.

**Fresh-clone test failure**

The e2e suite spawns `dist/index.js`, so it silently required a prior `npm run build`. On a clean checkout `npm run test:coverage` failed 11 tests with `Server exited with code 1 during startup`. CI passed only because its build step happens to run first. A vitest `globalSetup` now compiles when `dist/` is missing or stale.

`@vitest/ui` was also added — `test:ui` and both contributor guides document it, but it was never a devDependency.

129 → 157 tests. Coverage 97.15% statements / 91.34% branches / 100% functions.

## Build & release plumbing

**Eval sets deleted by #94** (`fix:`)

#94 gitignored `evals/` wholesale to stop tracking benchmark output, but that directory also held the three hand-maintained eval sets, which are inputs. Removing them broke `evaluate_skill` for every shipped skill (its default lookup is `evals/<skill_name>.json`) and both `skills:benchmark-shipped*` scripts. Restored; the ignore is narrowed to `evals/results/`, and both scripts write there so output can't be cleaned up with its inputs again.

**LSM-5 — dependency bumps never released** (`ci:`)

Dependabot stamped every npm update `chore`, which `.releaserc.json` maps to `release: false`. With auto-merge on, a production security bump landed on `main`, merged itself, and produced no release. Production bumps now use `fix`; development bumps stay `chore`. Verified through the repo's own `releaseRules` via `@semantic-release/commit-analyzer`:

| commit | before | after |
|---|---|---|
| `fix(deps): bump @modelcontextprotocol/sdk …` | — | **patch** |
| `chore(deps): bump @modelcontextprotocol/sdk …` | no release | — |
| `chore(deps-dev): bump vitest …` | no release | no release |
| `ci(deps): bump actions/checkout …` | no release | no release |

**LSM-7 — runtime dependencies** (`fix:`)

`yaml` → 2.9.0 and `@modelcontextprotocol/sdk` → 1.30.0. The `yaml` advisory (GHSA-48c2-rrv3-qjmp, stack overflow on deeply nested collections) is the one on the list that sits directly in this server's input path — that parser reads SKILL.md frontmatter.

Production advisories: **7 (3 high, 4 moderate) → 2 (1 high, 1 moderate)**. The remaining two are `ajv` and its `fast-uri` dependency, pinned by the SDK at its current release and not resolvable by `npm audit fix`; both are URI/schema paths reached through the SDK's HTTP transports, which this stdio-only server does not use.

Dev-dependency majors (vitest 2→4, eslint 9→10, typescript 5→7) are left to Dependabot, which can now cut releases for runtime bumps on its own.

**LSM-8 — changelog** (`docs:`)

Backfilled 0.4.3 and 0.4.4 from the tag ranges, in the format semantic-release generates.

**Formatting drift** (`style:`)

`npm run format:check` failed on 14 tracked files. Since lint-staged runs prettier on every staged file, anyone touching one picked up unrelated reformatting in their diff. Reformatted once, and `format:check` added to CI — which ran lint, typecheck and tests but never the formatter.

## Not included

- **LSM-4** (release pipeline / `RELEASE_TOKEN`) — human action per the brief. Nothing here is released until that's resolved.
- **LSM-6** (Node matrix → `[22, 24]`, `engines: ">=22"`) — breaking, and the brief orders it after LSM-4 as a deliberate release rather than something slipped in quietly.

## Commit types

Per the brief's first ground rule, the security and correctness fixes are `fix:` so they actually reach npm once LSM-4 is resolved. `style:`, `test:` and `ci:` commits here are intentionally non-releasing.

## Verification

`npm run build`, `lint`, `format:check`, `typecheck` all clean; 157/157 tests pass with both a populated and an empty `HOME`; coverage thresholds met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi
