### PR TITLE
fix: re-pin dead anthropic-skills submodule, unblocking clones and Dependabot

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,10 @@ coverage
 *.min.js
 package-lock.json
 .tmp
+
+# Vendored third-party source (git submodule) — not ours to format.
+# eslint.config.js already ignores this path.
+vendor
+
+# Generated eval/benchmark artifacts
+evals/results


### PR DESCRIPTION
Fixes a dead submodule pin that was breaking cloning, Dependabot, and the eval tooling simultaneously. Found while checking why the Dependabot Updates jobs failed right after #95 merged — they were unrelated to that PR.

## The problem

`vendor/anthropic-skills` pointed at `4fc507e`, which no longer exists in `anthropics/skills`; that history was rewritten upstream. Any recursive clone fails:

```
$ git clone --recurse-submodules https://github.com/kdpa-llc/local-skills-mcp.git
Submodule 'vendor/anthropic-skills' (https://github.com/anthropics/skills) registered
fatal: remote error: upload-pack: not our ref 4fc507eff8c6d2e46aec495f1b2052126b2ae2cd
fatal: Fetched in submodule path 'vendor/anthropic-skills', but it did not contain
       4fc507eff8c6d2e46aec495f1b2052126b2ae2cd. Direct fetching of that commit failed.
```

Three consequences:

1. **Cloning** — the `--recurse-submodules` form fails for everyone.
2. **Dependabot** — it clones with submodules, so every update job aborted during file fetching:
   ```
   ERROR <job_1533449446> Error during file fetching; aborting: Cloning into ...
   ```
   No dependency update could complete. Worth noting this would have silently neutered the release-trigger fix in #95: `prefix: "fix"` is correct in the job definition, but no job was reaching the point of opening a PR.
3. **Eval tooling** — `evaluate_skill` and `skills:benchmark-shipped*` had no `run_loop.py` to invoke.

## The fix

Re-pinned to `0a64e39`, current upstream HEAD. That commit still ships `skills/skill-creator/scripts/run_loop.py`, the modern layout `eval-runner.ts` already prefers, so no code change was needed.

Verified a recursive clone of this branch now succeeds, and the runner detects it:

```
run_loop found at: vendor/anthropic-skills/skills/skill-creator/scripts/run_loop.py
invocation: module
ok: true
missing: (none)
```

Together with the eval sets restored in #95, the eval pipeline is functional again end to end.

## Second commit: prettier ignore

Populating the submodule made `npm run format:check` fail on **88 vendored files**, and `npm run format` would have rewritten third-party source. `eslint.config.js` already ignored `vendor/**`; `.prettierignore` did not.

CI never saw this because `actions/checkout` doesn't fetch submodules by default, so `vendor/` is empty there. But anyone following the documented clone would hit it immediately — and the `format:check` job added in #95 would fail for reasons they didn't cause. Also ignores `evals/results`, which holds generated artifacts.

## Verification

`lint`, `typecheck`, `format:check` clean with the submodule populated; 157/157 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi
