### PR TITLE
feat!: require Node.js 22+ and test on Node 22/24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [22, 24]
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
-        if: matrix.os == 'ubuntu-latest' && matrix.node == 20
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 22
         with:
           files: ./coverage/coverage-final.json
           flags: unittests
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -4,7 +4,7 @@ Get up and running with Local Skills MCP in 5 minutes!
 
 ## Prerequisites
 
-- Node.js 18+ installed
+- Node.js 22+ installed
 - Claude Code or another MCP-compatible client
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Transform AI capabilities with structured, expert-level instructions for special
 
 ### 1. Install
 
-**Requirements:** Node.js 18+
+**Requirements:** Node.js 22+
 
 Choose one installation method:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@semantic-release/github": "^12.0.2",
         "@semantic-release/npm": "^13.1.3",
         "@semantic-release/release-notes-generator": "^14.1.0",
-        "@types/node": "^24.10.1",
+        "@types/node": "^22.20.1",
         "@typescript-eslint/eslint-plugin": "^8.49.0",
         "@typescript-eslint/parser": "^8.49.0",
         "@vitest/coverage-v8": "^4.1.11",
@@ -44,7 +44,7 @@
         "vitest": "^4.1.11"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@actions/core": {
@@ -1990,13 +1990,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -10029,9 +10029,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "url": "https://github.com/kdpa-llc/local-skills-mcp/issues"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
@@ -100,7 +100,7 @@
     "@semantic-release/github": "^12.0.2",
     "@semantic-release/npm": "^13.1.3",
     "@semantic-release/release-notes-generator": "^14.1.0",
-    "@types/node": "^24.10.1",
+    "@types/node": "^22.20.1",
     "@typescript-eslint/eslint-plugin": "^8.49.0",
     "@typescript-eslint/parser": "^8.49.0",
     "@vitest/coverage-v8": "^4.1.11",


### PR DESCRIPTION
## ✅ Decisions confirmed by the maintainer

Both questions this PR raised have been answered, and the branch already matches:

| Question | Decision | State on this branch |
|---|---|---|
| Cut 1.0.0, or stay 0.x? | **Cut 1.0.0** | `feat!:` + `BREAKING CHANGE:` footer — verified to resolve to `major` |
| `@types/node` `^22` or latest `^26`? | **`^22`, match the floor** | `"@types/node": "^22.20.1"` |

No changes needed. This PR is ready to merge as-is, and will make the first release after LSM-4 a **1.0.0**.

---

LSM-6 from the remediation brief. **Stacked on #97** (which is stacked on #96); GitHub retargets as those merge.

## ⚠️ This would cut 1.0.0

Verified against the repo's own `releaseRules` via `@semantic-release/commit-analyzer`:

```
major  <- "feat!: require Node.js 22+ and test on Node 22/24 … BREAKING CHANGE: …"
```

From 0.4.4, semantic-release takes a breaking change to **1.0.0**. That is a deliberate milestone, not a side effect — so this PR is a decision to make, not just a merge. If you would rather stay on 0.x for now, say so and I will restate it as `feat:` with the Node drop noted in the body instead.

The brief called LSM-6 "a good candidate for the first release after LSM-4 is resolved, rather than something to slip in quietly" — this is that PR, sitting ready for whenever the release token is fixed.

## Why

Two of three matrix entries were end-of-life, and the runtime users are most likely on was not tested at all:

| Version | Status (2026-08-20) | Before | After |
|---|---|---|---|
| 18 | EOL 2025-04-30 | tested | dropped |
| 20 | EOL 2026-04-30 | tested | dropped |
| 22 | Maintenance LTS | tested | **floor** |
| 24 | Active LTS | untested | **tested** |

## Changes

- CI matrix `[18, 20, 22]` → `[22, 24]`; Codecov upload and the build job move from Node 20 to 22.
- `engines.node` `>=18.0.0` → `>=22.0.0`.
- README and QUICK_START requirement lines updated.

## A deliberate choice on @types/node

Pinned to **`^22`, not the latest `^26`**, which is numerically a step back from the current `^24`.

The types should match the *lowest* supported runtime, not the newest. On `^26`, code calling a Node 24-or-26-only API would type-check cleanly and then fail at runtime for anyone on the supported floor of 22 — the types would be actively hiding the bug they exist to catch. `^22` makes the floor enforceable at compile time.

This is what "track the engines bump" means in practice. Bump it in lockstep the next time the floor rises. If you would rather have latest types and accept that gap, it is a one-line change.

## Verification

Build, lint, typecheck and format:check clean; 157/157 tests pass; typecheck passes against Node 22 types specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi
