### PR TITLE
ci: make release-token failures readable and run CI on stacked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main, develop]
+  # Deliberately unfiltered: a PR based on another PR's branch is still code
+  # heading for main, and a base filter of [main, develop] silently skipped it.
   pull_request:
-    branches: [main, develop]
 
 jobs:
   test:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,8 @@ name: CodeQL
 on:
   push:
     branches: [main, develop]
+  # Unfiltered so stacked PRs are scanned too. See ci.yml.
   pull_request:
-    branches: [main, develop]
   schedule:
     # Run at 00:00 UTC every Monday
     - cron: '0 0 * * 1'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,8 +1,8 @@
 name: Dependency Review
 
 on:
+  # Unfiltered so stacked PRs are reviewed too. See ci.yml.
   pull_request:
-    branches: [main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Runs before checkout so a credential problem is reported as itself.
+      # Without this, an expired RELEASE_TOKEN surfaces only as
+      # "could not read Username for 'https://github.com'" plus git exit 128
+      # from the checkout step, which reads like a git fault rather than an
+      # expired secret. That ambiguity kept the pipeline broken, and silent,
+      # for 279 days.
+      - name: Verify RELEASE_TOKEN
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_TOKEN" ]; then
+            echo "::error title=RELEASE_TOKEN missing::The RELEASE_TOKEN secret is not set for this repository. semantic-release pushes the release commit to a protected branch, so the default GITHUB_TOKEN cannot be used. Add a PAT or GitHub App token whose identity is allowed to bypass the branch protection on main."
+            exit 1
+          fi
+
+          status=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $RELEASE_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/user || echo "000")
+
+          if [ "$status" != "200" ]; then
+            echo "::error title=RELEASE_TOKEN rejected::GitHub returned HTTP $status for the RELEASE_TOKEN secret. It is most likely expired or revoked (a PAT that has expired looks identical to a missing one at the git layer). Reissue it, or move to a GitHub App token, which does not expire the same way."
+            exit 1
+          fi
+
+          echo "RELEASE_TOKEN accepted by the GitHub API."
+
       - name: Checkout
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Two CI-configuration fixes, both about failures being invisible rather than about code. Independent of #96/#97/#98 — branches from `main`, merges in any order.

## 1. A bad RELEASE_TOKEN now fails readably

This does **not** fix LSM-4; reissuing the token is a human action. It fixes the reason LSM-4 went unnoticed for 279 days.

The release pipeline broke on 2025-11-11 and stayed silent because the failure does not look like a credentials problem:

```
could not read Username for 'https://github.com': terminal prompts disabled
The process '/usr/bin/git' failed with exit code 128
```

That is `actions/checkout` dying at step one, and it reads like a git fault. The remediation brief's elimination argument landed on the wrong step because of this — it reasoned that since lint, typecheck and test pass on HEAD, the job must reach `npx semantic-release` and fail at auth-and-push. It never gets that far: **nothing after Checkout runs.**

```
✓ Set up job
X Checkout          ← dies here
- Setup Node.js     ─┐
- Install deps       │ never reached
- Run linter         │
- Build / Test       │
- Release           ─┘
```

An expired PAT and an absent secret are indistinguishable at the git layer, which is exactly why the brief could only mark its diagnosis `INFERRED`.

A preflight step before checkout now tells the two apart:

- **Secret absent** → explains that semantic-release pushes to a protected branch so `GITHUB_TOKEN` cannot substitute, and that the token's identity needs the branch-protection bypass (`rkdpa` is currently the sole entry in `bypass_pull_request_allowances`).
- **Secret present but rejected** → reports the HTTP status from `api.github.com/user` and points at reissuing or moving to a GitHub App token.

Both emit `::error title=…::` so the reason lands in the run summary. Once the token works, the step is a sub-second no-op.

## 2. Stacked PRs were getting no CI at all

`ci.yml`, `codeql.yml` and `dependency-review.yml` all filtered on `pull_request: branches: [main, develop]`. A PR based on another branch therefore got **no build, no tests, no CodeQL, no dependency review** — only the label and welcome bots.

Found this the direct way: #97 and #98 are stacked, and both currently show zero substantive checks. Their code is still headed for `main`; it just arrives via an intermediate branch. A base filter is the wrong tool for deciding whether to test a change.

All three now trigger on `pull_request` unfiltered. `push` stays scoped to main/develop so branch pushes don't double-run.

Merging this first means #97 and #98 get real CI without waiting to be retargeted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi
