### PR TITLE
docs: fix nonexistent function and false caching claims in bundled skills

### DIFF
--- a/skills/local-skills-mcp-guide/SKILL.md
+++ b/skills/local-skills-mcp-guide/SKILL.md
@@ -70,14 +70,21 @@ local-skills-mcp/
   - `$SKILLS_DIR` (user-defined custom directory)
 - Parses SKILL.md files with YAML frontmatter
 - Validates skill format (name, description requirements)
-- Implements skill caching for performance
+- Reads skill content fresh from disk on every request, so edits to a SKILL.md
+  take effect without restarting the server. Only the registry (skill name ->
+  directory) is held in memory; skill content is never cached.
 - Resolves skill name conflicts (later directories override earlier)
 
 **Important functions**:
 
-- `loadSkills()` - Main aggregation function
-- YAML frontmatter parsing
-- Skill validation logic
+- `getAllSkillsDirectories()` in `src/index.ts` - builds the directory list and
+  its priority order
+- `SkillLoader.discoverSkills()` - scans those directories and rebuilds the
+  name -> directory registry
+- `SkillLoader.loadSkill()` - reads and parses one SKILL.md, fresh each call
+- `SkillLoader.getSkillLocation()` - registry lookup without parsing, used by
+  `validate_skill` and `evaluate_skill` so a malformed file can still be
+  inspected
 
 ### 3. Type Definitions (src/types.ts)
 
@@ -95,7 +102,7 @@ local-skills-mcp/
 
 1. Server starts via stdio transport
 2. Skill loader aggregates skills from all configured directories
-3. Skills are validated and cached in memory
+3. Skill names are validated and recorded in the in-memory registry (content is not cached)
 4. MCP server initializes and registers the skill tools
 5. `get_skill` description is generated with current skill list and metadata
 
@@ -161,10 +168,10 @@ A: It aggregates from multiple locations: `~/.claude/skills/`, `./.claude/skills
 A: Via the Model Context Protocol over stdio transport. See `src/index.ts` for the server implementation.
 
 **Q: How are SKILL.md files parsed?**
-A: `skill-loader.ts` reads files, extracts YAML frontmatter, validates required fields, and caches the parsed content.
+A: `skill-loader.ts` reads files, extracts YAML frontmatter and validates required fields. It does not cache parsed content — each request re-reads the file, which is what makes hot reload work.
 
 **Q: How can I modify Local Skills MCP's skill aggregation?**
-A: Edit the `loadSkills()` function in `src/skill-loader.ts` to add new directories or change priority.
+A: Edit `getAllSkillsDirectories()` in `src/index.ts` — that function builds the directory list, and its order is the priority order (later entries win on duplicate skill names). `SkillLoader` receives that list and does not decide it.
 
 **Q: What's the build process?**
 A: TypeScript source in `src/` compiles to JavaScript in `dist/` using `npm run build`. The `prepare` script runs automatically on install.

--- a/skills/local-skills-mcp-usage/SKILL.md
+++ b/skills/local-skills-mcp-usage/SKILL.md
@@ -531,4 +531,4 @@ When users ask you to create or work with skills:
    - Offer to test the skill immediately
    - Willing to refine based on usage
 
-Remember: You can create skills directly by writing files to the appropriate directories. New skills appear immediately when the tool list refreshes - no restart needed! (Content changes to existing skills still require a server restart due to caching.)
+Remember: You can create skills directly by writing files to the appropriate directories. New skills appear immediately when the tool list refreshes, and edits to an existing SKILL.md are picked up on the next `get_skill` call - no restart needed in either case, because skill content is read fresh from disk every time.


### PR DESCRIPTION
Independent of the other open PRs — branches from `main`. Content only; no code, and **no frontmatter changes**, so the eval-tuned descriptions and their eval sets are untouched.

These skills ship inside the npm package (`skills/**/*` is in `files`). They are what an agent loads to learn this codebase, which means a wrong statement here doesn't get skimmed past — it gets followed.

## A function that does not exist

`local-skills-mcp-guide` pointed contributors at `loadSkills()`. Twice:

> `loadSkills()` - Main aggregation function

> **Q: How can I modify Local Skills MCP's skill aggregation?**
> A: Edit the `loadSkills()` function in `src/skill-loader.ts` to add new directories or change priority.

There is no `loadSkills()` anywhere in `src/`. Directory aggregation is `getAllSkillsDirectories()` — a different function, in a different file (`src/index.ts`), and `SkillLoader` merely receives the list it produces. Anyone acting on that answer went looking in the wrong file for something that was never there.

Replaced with the functions that do exist, including `getSkillLocation()` — worth naming because it is why `validate_skill` can inspect a `SKILL.md` whose frontmatter fails to parse, where `loadSkill()` would throw first.

## Caching that does not happen

Both bundled skills described a content cache. The usage skill's **closing line** stated the opposite of the truth:

> Remember: … (Content changes to existing skills still require a server restart due to caching.)

The loader re-reads `SKILL.md` on every request precisely so that it doesn't. Verified against the built loader rather than inferred from the source — editing a `SKILL.md` between two `loadSkill()` calls inside one process:

```
1st load: ORIGINAL BODY
2nd load (same process, no restart): EDITED BODY
=> HOT RELOAD WORKS, no restart needed
```

The same file already said this correctly around line 345, so it contradicted itself — and the wrong version was the last thing a reader saw. Hot reload is a feature the README advertises; the shipped skill was telling users it doesn't work.

Also corrected: "Skills are validated and cached in memory" → only the registry (name → directory) is held in memory.

## Verification

All three bundled skills still validate with **zero errors and zero warnings** via `validate_skill`. `prettier --check` clean on both edited files. Frontmatter untouched, confirmed by diff, so the benchmark-tuned descriptions and `evals/*.json` remain valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi
