### PR TITLE
ci: set npm registry in release workflow so publishing can authenticate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,15 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
+          # Required for either npm auth path:
+          #  - Trusted publishing (OIDC): npm >= 11.5.1 uses the id-token
+          #    permission declared above once a trusted publisher for this
+          #    workflow is configured on npmjs.com. No secret involved.
+          #  - NPM_TOKEN: semantic-release writes its own .npmrc from the
+          #    NPM_TOKEN env var set on the Release step.
+          # publish.yml already used OIDC; release.yml did not set a registry,
+          # so the two publish paths disagreed about how they authenticate.
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Found while diagnosing why the Release run still failed after the seven merges landed. This is a **second blocker** that would have surfaced only after `RELEASE_TOKEN` was fixed.

## The problem

`release.yml` line 84 passes `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` to semantic-release. That secret **does not exist** — the repository has exactly one secret:

```
RELEASE_TOKEN  updated=2025-11-12
```

So it expands to an empty string, and `@semantic-release/npm` (running with default config, no OIDC) would fail at `npm publish` with a 401 — immediately after you finish fixing the *other* 401.

The two publish paths also disagreed with each other. `publish.yml` uses OIDC trusted publishing and says so:

```yaml
registry-url: 'https://registry.npmjs.org'
# No NODE_AUTH_TOKEN needed - uses OIDC for authentication
```

`release.yml` set no registry at all and expected a token.

## The change

Sets `registry-url` on the Setup Node.js step, which makes it work for **either** auth path:

- **Trusted publishing** — npm ≥ 11.5.1 uses the `id-token: write` permission the workflow already declares, once a trusted publisher for this workflow is configured on npmjs.com. Nothing to expire.
- **NPM_TOKEN** — semantic-release writes its own `.npmrc` from the env var.

This does not by itself authorise a publish; one of the two still has to be set up. What it removes is the misconfiguration that would have failed the release a second time for a different reason.

## Still needed from a maintainer

1. **Reissue `RELEASE_TOKEN`** as `rkdpa` (sole entry in `bypass_pull_request_allowances`; `@semantic-release/git` pushes to protected `main`, so `GITHUB_TOKEN` can't substitute). Confirmed expired: the preflight added in #99 now reports `HTTP 401` in 3 seconds instead of a bare `git exit 128` after 40.
2. **Configure npm auth** — trusted publisher on npmjs.com (recommended, matches `publish.yml`), or set `NPM_TOKEN`.

Then `gh workflow run release.yml` should publish **1.0.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi
