### PR TITLE
ci: allow the release workflow to be triggered manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
       - next
       - beta
       - alpha
+  # Lets a release be retried without an empty commit. Needed whenever a run
+  # failed for a reason outside the code — an expired RELEASE_TOKEN or missing
+  # npm credentials — where the fix is a settings change, not a push.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
`release.yml` only fired on `push`, so a release that failed for a reason *outside the code* could not be retried without inventing an empty commit.

That is exactly the situation the repo is in — the last three Release runs failed on an expired `RELEASE_TOKEN` and missing npm credentials, both fixed by changing settings rather than pushing code. Discovered concretely: `gh workflow run release.yml` returns

```
HTTP 422: Workflow does not have 'workflow_dispatch' trigger
```

Adds `workflow_dispatch` so the release can be retried on demand once credentials are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi