### PR TITLE
fix(deps): pin conventionalcommits preset to a writer-8 compatible major

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@typescript-eslint/parser": "^8.49.0",
         "@vitest/coverage-v8": "^4.1.11",
         "@vitest/ui": "^4.1.11",
+        "conventional-changelog-conventionalcommits": "^7.0.2",
         "eslint": "^10.8.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
@@ -217,6 +218,19 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
+      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -3120,16 +3134,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
-      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.4.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@typescript-eslint/parser": "^8.49.0",
     "@vitest/coverage-v8": "^4.1.11",
     "@vitest/ui": "^4.1.11",
+    "conventional-changelog-conventionalcommits": "^7.0.2",
     "eslint": "^10.8.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",


### PR DESCRIPTION
**I introduced this in #97**, and fixing `RELEASE_TOKEN` surfaced it.

## What broke

Bumping `@commitlint/config-conventional` 20 → 21 changed its preset dependency:

| version | preset dependency | works with writer 8? |
|---|---|---|
| v20 (before) | `conventional-changelog-conventionalcommits@^7.0.2` | ✅ |
| v21 (my bump) | `conventional-changelog-conventionalcommits@^10.0.0` | ❌ needs writer ≥9 |

npm hoisted the v10 copy to the top level — which is exactly where semantic-release resolves the `"preset": "conventionalcommits"` named in `.releaserc.json`. It then paired that preset with `conventional-changelog-writer@8`, pinned by `@semantic-release/release-notes-generator@14.1.1` (`^8.0.0`, and 14.1.1 is latest), producing:

```
Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer (conventional-changelog@8 or newer)."
```

It went unnoticed because **the release never reached `generateNotes`** — the expired token killed the job at checkout. With the token fixed, the run now gets all the way through install, lint, typecheck, build and tests before dying here.

## The fix

Declaring `conventional-changelog-conventionalcommits@^7` directly puts a writer-8-compatible copy at the top level for semantic-release, while `@commitlint/config-conventional` keeps its own nested `^10`:

```
├─┬ @commitlint/config-conventional@21.2.2
│ └── conventional-changelog-conventionalcommits@10.4.0
└── conventional-changelog-conventionalcommits@7.0.2   ← semantic-release uses this
```

Both tools get the version they need; commitlint stays on 21.

## Verification

Invoked the plugin directly rather than inferring:

```
on main:      generateNotes FAILED: Missing helper: ...
on this PR:   generateNotes OK, length: 118
```

commitlint still accepts a valid message and rejects an invalid one. `lint`, `typecheck`, `format:check` clean; 157/157 tests pass.

Drop this pin once `@semantic-release/release-notes-generator` supports `conventional-changelog-writer@9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi