### PR TITLE
feat!: signal the Node.js 22 requirement and make "!" mark a breaking change

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -20,21 +20,60 @@
       {
         "preset": "conventionalcommits",
         "releaseRules": [
-          { "type": "feat", "release": "minor" },
-          { "type": "fix", "release": "patch" },
-          { "type": "perf", "release": "patch" },
-          { "type": "revert", "release": "patch" },
-          { "type": "docs", "release": "patch" },
-          { "type": "style", "release": false },
-          { "type": "refactor", "release": "patch" },
-          { "type": "test", "release": false },
-          { "type": "build", "release": "patch" },
-          { "type": "ci", "release": false },
-          { "type": "chore", "release": false },
-          { "breaking": true, "release": "major" }
+          {
+            "type": "feat",
+            "release": "minor"
+          },
+          {
+            "type": "fix",
+            "release": "patch"
+          },
+          {
+            "type": "perf",
+            "release": "patch"
+          },
+          {
+            "type": "revert",
+            "release": "patch"
+          },
+          {
+            "type": "docs",
+            "release": "patch"
+          },
+          {
+            "type": "style",
+            "release": false
+          },
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "type": "test",
+            "release": false
+          },
+          {
+            "type": "build",
+            "release": "patch"
+          },
+          {
+            "type": "ci",
+            "release": false
+          },
+          {
+            "type": "chore",
+            "release": false
+          },
+          {
+            "breaking": true,
+            "release": "major"
+          }
         ],
         "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"],
+          "headerPattern": "^(\\w*)(?:\\(([^)]*)\\))?!?: (.*)$",
+          "headerCorrespondence": ["type", "scope", "subject"],
+          "breakingHeaderPattern": "^(\\w*)(?:\\(([^)]*)\\))?!: (.*)$"
         }
       }
     ],
@@ -44,22 +83,61 @@
         "preset": "conventionalcommits",
         "presetConfig": {
           "types": [
-            { "type": "feat", "section": "Features" },
-            { "type": "fix", "section": "Bug Fixes" },
-            { "type": "perf", "section": "Performance Improvements" },
-            { "type": "revert", "section": "Reverts" },
-            { "type": "docs", "section": "Documentation" },
-            { "type": "style", "section": "Styles", "hidden": true },
-            { "type": "refactor", "section": "Code Refactoring" },
-            { "type": "test", "section": "Tests", "hidden": true },
-            { "type": "build", "section": "Build System" },
+            {
+              "type": "feat",
+              "section": "Features"
+            },
+            {
+              "type": "fix",
+              "section": "Bug Fixes"
+            },
+            {
+              "type": "perf",
+              "section": "Performance Improvements"
+            },
+            {
+              "type": "revert",
+              "section": "Reverts"
+            },
+            {
+              "type": "docs",
+              "section": "Documentation"
+            },
+            {
+              "type": "style",
+              "section": "Styles",
+              "hidden": true
+            },
+            {
+              "type": "refactor",
+              "section": "Code Refactoring"
+            },
+            {
+              "type": "test",
+              "section": "Tests",
+              "hidden": true
+            },
+            {
+              "type": "build",
+              "section": "Build System"
+            },
             {
               "type": "ci",
               "section": "Continuous Integration",
               "hidden": true
             },
-            { "type": "chore", "section": "Chores", "hidden": true }
+            {
+              "type": "chore",
+              "section": "Chores",
+              "hidden": true
+            }
           ]
+        },
+        "parserOpts": {
+          "headerPattern": "^(\\w*)(?:\\(([^)]*)\\))?!?: (.*)$",
+          "headerCorrespondence": ["type", "scope", "subject"],
+          "breakingHeaderPattern": "^(\\w*)(?:\\(([^)]*)\\))?!: (.*)$",
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
         }
       }
     ],
@@ -81,8 +159,14 @@
       "@semantic-release/github",
       {
         "assets": [
-          { "path": "dist/**", "label": "Distribution files" },
-          { "path": "CHANGELOG.md", "label": "Changelog" }
+          {
+            "path": "dist/**",
+            "label": "Distribution files"
+          },
+          {
+            "path": "CHANGELOG.md",
+            "label": "Changelog"
+          }
         ]
       }
     ],


### PR DESCRIPTION
Cuts **1.0.0**, and fixes the reason 0.5.0 wasn't it.

## What went wrong

0.5.0 shipped a breaking change without saying so. #98 dropped Node 18 and 20 and raised `engines` to `>=22`, but semantic-release classified the release as **minor** — so anyone on Node 18 received it as a routine upgrade.

I predicted 1.0.0 and was wrong. Two independent causes, both verified against the installed plugins rather than inferred:

**1. The preset doesn't understand `!`.** `conventional-changelog-conventionalcommits@7` fails to extract a type at all:

```
"feat!: require Node.js 22+ (#98)"   ->  type: undefined, notes: []
"feat: plain feature"                ->  type: feat
```

So #98's commit contributed **nothing** to the version calculation. 0.5.0 came entirely from the ordinary `feat:` commits in the range.

**2. #98 was squash-merged**, which replaced the body and dropped the `BREAKING CHANGE:` footer that would have registered regardless of the `!`.

My earlier verification tested the *branch* commit — which still had its footer — and correctly returned `major`. I never tested the form the commit would take *after merging*.

## The fix

`parserOpts` now sets `headerPattern` and `breakingHeaderPattern` for both `commit-analyzer` and `release-notes-generator`, so `!` is parsed and treated as breaking:

```
major       <- feat!: ...  (no footer)
major       <- fix!: ...   (no footer)
major       <- feat! with BREAKING CHANGE footer
minor       <- feat: ...
patch       <- fix: ...
no release  <- chore: ...
```

`generateNotes` renders the BREAKING CHANGE section correctly. Belt and braces: this commit carries both the `!` and an explicit footer, so it releases as major even if squashed.

Verified on the actual commit message: `release type: major => from 0.5.0 gives 1.0.0`.

**Merge this with a merge commit, not a squash** — though with the parser fix in place, `!` alone would now survive a squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi