### PR TITLE
fix: remove SIGINT listener on close, and collapse the duplicated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,25 +151,11 @@ Claude-Session: https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi
 - chore(deps-dev): bump the development-dependencies group with 2 updates (#37) ([6ce77d2](https://github.com/kdpa-llc/local-skills-mcp/commit/6ce77d2)), closes [#37](https://github.com/kdpa-llc/local-skills-mcp/issues/37)
 - docs: replace hardcoded values with dynamic references (#20) ([45a8d80](https://github.com/kdpa-llc/local-skills-mcp/commit/45a8d80)), closes [#20](https://github.com/kdpa-llc/local-skills-mcp/issues/20) [#20](https://github.com/kdpa-llc/local-skills-mcp/issues/20)
 
-# Changelog
+## Earlier history
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### Added
-
-- Package built-in skills directory as base default for all MCP instances
-- Self-documenting capabilities: `local-skills-mcp-usage`, `local-skills-mcp-guide`, and `skill-creator` skills
-- Skills are now available immediately after installation with zero configuration
-
-### Changed
-
-- Directory aggregation priority updated to include package built-in skills as lowest priority (first in list)
-- Updated documentation to reflect new built-in skills feature
+Entries below predate semantic-release taking over this file. They are kept
+verbatim; the `[Unreleased]` block that used to sit here described the
+built-in skills feature, which shipped in 0.2.0 and is covered above.
 
 ## [0.1.0] - 2025-11-01
 

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -2,9 +2,6 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { spawn, ChildProcess } from "child_process";
 import { resolve } from "path";
 
-// Increase max listeners to prevent warnings during tests
-process.setMaxListeners(20);
-
 /**
  * End-to-End tests for Local Skills MCP Server
  *

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,9 +10,6 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 
-// Increase max listeners to prevent warnings during tests
-process.setMaxListeners(20);
-
 /**
  * Safely remove a directory with retries for Windows file locking issues.
  * Windows can be slower to release file handles, causing EBUSY errors.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -815,23 +815,31 @@ This is test skill content.`
 
     const serverInternal = server as any;
     const mockServer = serverInternal.server;
+    const previousExitCode = process.exitCode;
 
-    // Find the SIGINT handler that was added
-    const sigintListeners = process.listeners("SIGINT");
-    const ourHandler = sigintListeners[sigintListeners.length - 1];
+    // shutdown() is what the SIGINT listener delegates to. Awaiting it
+    // directly makes the assertion deterministic - the listener itself is
+    // fire-and-forget, so awaiting that returns before close() settles, which
+    // is how the real process.exit() previously escaped the spy.
+    await server.shutdown();
 
-    // Mock process.exit to avoid actually exiting
-    const mockExit = vi
-      .spyOn(process, "exit")
-      .mockImplementation((() => {}) as any);
+    expect(mockServer.close).toHaveBeenCalled();
+    expect(process.exitCode).toBe(0);
 
-    // Trigger the handler
-    if (typeof ourHandler === "function") {
-      await (ourHandler as any)();
-      expect(mockServer.close).toHaveBeenCalled();
-    }
+    process.exitCode = previousExitCode;
+  });
 
-    mockExit.mockRestore();
+  it("should remove its SIGINT listener on close", async () => {
+    const before = process.listenerCount("SIGINT");
+
+    const scoped = new LocalSkillsServer();
+    expect(process.listenerCount("SIGINT")).toBe(before + 1);
+
+    await scoped.close();
+
+    // The leak this guards: one listener per constructed server, never
+    // removed, which tripped MaxListenersExceededWarning across a test run.
+    expect(process.listenerCount("SIGINT")).toBe(before);
   });
 
   it("should run the server and connect to transport", async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -842,6 +842,55 @@ This is test skill content.`
     expect(process.listenerCount("SIGINT")).toBe(before);
   });
 
+  it("should shut down when the registered SIGINT listener fires", async () => {
+    const before = process.listeners("SIGINT");
+    server = new LocalSkillsServer();
+    const previousExitCode = process.exitCode;
+
+    const serverInternal = server as any;
+    const added = process
+      .listeners("SIGINT")
+      .filter((listener) => !before.includes(listener));
+    expect(added).toHaveLength(1);
+
+    // Invoke the listener the way Node would. It returns void, so wait on the
+    // end state rather than the call: close() being invoked does not mean the
+    // shutdown finished, and the exit status is set a microtask later.
+    process.exitCode = undefined;
+    (added[0] as () => void)();
+    await vi.waitFor(() => {
+      expect(process.exitCode).toBe(0);
+    });
+
+    expect(serverInternal.server.close).toHaveBeenCalled();
+    process.exitCode = previousExitCode;
+  });
+
+  it("should report a non-zero exit status when close fails", async () => {
+    server = new LocalSkillsServer();
+
+    const serverInternal = server as any;
+    const previousExitCode = process.exitCode;
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    serverInternal.server.close = vi
+      .fn()
+      .mockRejectedValue(new Error("transport already gone"));
+
+    // shutdown() must swallow the failure rather than reject: it runs from a
+    // signal handler, where an unhandled rejection would replace a clean
+    // shutdown with a crash. The status is how the failure is reported.
+    await expect(server.shutdown()).resolves.toBeUndefined();
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    process.exitCode = previousExitCode;
+    consoleErrorSpy.mockRestore();
+  });
+
   it("should run the server and connect to transport", async () => {
     server = new LocalSkillsServer();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,11 +248,31 @@ export class LocalSkillsServer {
    * MaxListenersExceededWarning.
    */
   private readonly handleSigint = (): void => {
-    void this.close().then(
-      () => process.exit(0),
-      () => process.exit(1)
-    );
+    void this.shutdown();
   };
+
+  /**
+   * Close the server and set the exit status, without calling process.exit().
+   *
+   * close() removes the SIGINT listener and closes the transport, leaving
+   * nothing to hold the event loop, so the process ends on its own with this
+   * status. Forcing the exit truncates whatever else is still unwinding, and
+   * is untestable here: process.exit() inside a fire-and-forget handler
+   * escapes any spy a test installs, because the handler returns before the
+   * promise settles. Vitest then reports "process.exit unexpectedly called"
+   * and fails the run even though every test passed.
+   *
+   * Returned so callers - and tests - can await the shutdown deterministically.
+   */
+  async shutdown(): Promise<void> {
+    try {
+      await this.close();
+      process.exitCode = 0;
+    } catch (error) {
+      console.error("[MCP Error] Failed to close cleanly", error);
+      process.exitCode = 1;
+    }
+  }
 
   private setupHandlers(): void {
     // List available tools (dynamically generated to include current skill list)

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,12 +236,23 @@ export class LocalSkillsServer {
       console.error("[MCP Error]", error);
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    process.on("SIGINT", async () => {
-      await this.server.close();
-      process.exit(0);
-    });
+    process.on("SIGINT", this.handleSigint);
   }
+
+  /**
+   * SIGINT handler, kept as a stable reference so {@link close} can remove it.
+   *
+   * Registering an inline listener per instance leaked one listener per server
+   * that was ever constructed: nothing removed them, so a process creating
+   * several servers — every test run — walked into
+   * MaxListenersExceededWarning.
+   */
+  private readonly handleSigint = (): void => {
+    void this.close().then(
+      () => process.exit(0),
+      () => process.exit(1)
+    );
+  };
 
   private setupHandlers(): void {
     // List available tools (dynamically generated to include current skill list)
@@ -548,6 +559,9 @@ export class LocalSkillsServer {
    * ```
    */
   async close(): Promise<void> {
+    // Drop the signal handler first so repeated construct/close cycles do not
+    // accumulate listeners on the process.
+    process.off("SIGINT", this.handleSigint);
     await this.server.close();
     // Allow time for all handles to be released (important on Windows)
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -6,9 +6,6 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 
-// Increase max listeners to prevent warnings during tests
-process.setMaxListeners(20);
-
 function extractAvailableSkills(description?: string): string[] {
   if (!description) {
     return [];


### PR DESCRIPTION
Findings **C** and **D** from the 24 Aug audit. Both verified before fixing.

Deliberately excludes **Finding A** (the lockfile desync) — another session is already on `fix/lockfile-desync`, and I confirmed their lockfile passes both npm majors. Touches no shared files with that work.

## C — SIGINT listener leak

Every `LocalSkillsServer` registered an inline SIGINT handler and nothing removed it, so listeners accumulated for the process lifetime. Three test files carried `process.setMaxListeners(20)` to silence the resulting warning — masking the leak rather than fixing it.

The handler is now a stable bound reference and `close()` removes it. Verified against the built server:

```
SIGINT listeners  before: 0   after 30 servers: 30   after closing all: 0
=> no leak
```

Previously the count stayed at 30. All three `setMaxListeners` workarounds are **deleted**, and the suite runs warning-free — so a regression surfaces instead of staying hidden.

## D — two `# Changelog` H1s

`@semantic-release/changelog` prepends generated entries, and the original hand-maintained Keep a Changelog file was left underneath — preamble, stale `## [Unreleased]` block and all. This is the file **npm renders on the package page**, so it appeared to start over halfway down.

- The `[Unreleased]` block described the built-in skills feature, which shipped in 0.2.0 and is already covered above → dropped.
- The 0.1.0 release notes and pre-release development history are genuinely historical and exist nowhere else → kept verbatim under an **Earlier history** heading.

262 → 248 lines, one H1, no orphaned Unreleased section.

## Verification

`build`, `lint`, `typecheck`, `format:check` clean; 157/157 tests pass.

## Note on the audit's Finding A

Worth recording for whoever fixes it: **regenerating the lock with npm 11 does not resolve it.** npm 11 reports `up to date` while npm 10 still rejects the same file. Regenerating with npm 10 produces a lock both majors accept (npm 10: 638 packages, npm 11: 612). The audit's "run `npm install`" is only correct if run on npm 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oP5dZ2WxDSSSpMoRtbASi