### PR TITLE
fix(deps): refresh vulnerable transitive dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3126,16 +3126,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/conventional-commits-filter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
-      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      }
-    },
     "node_modules/conventional-commits-parser": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
@@ -4601,9 +4591,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
-      "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5074,9 +5064,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -6042,9 +6032,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.19.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.19.0.tgz",
-      "integrity": "sha512-SDd/hHg3KqHE5Ht2NHWxNYNtqCQ2pXAPLl6OtQhPyED5PHsRfrOtO199MZTIG2cQoQ1ZRI9t28shrD+2cr3AAw==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.19.1.tgz",
+      "integrity": "sha512-ztsxKxt/kkIaAs+2i0GU6I+DRmUdrNasxTZKJe9TCdSjKxlhah/4r/hl5ygMD6XAg1qZ9c2TNomR4qgOydp10g==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -6152,7 +6142,7 @@
         "libnpmexec": "^10.3.2",
         "libnpmfund": "^7.0.26",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.12",
+        "libnpmpack": "^9.1.13",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -6181,7 +6171,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.19",
+        "tar": "^7.5.22",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -6663,7 +6653,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.7",
+      "version": "5.0.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6671,7 +6661,7 @@
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/npm/node_modules/cacache": {
@@ -6955,7 +6945,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7104,7 +7094,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.12",
+      "version": "9.1.13",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7814,7 +7804,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.19",
+      "version": "7.5.22",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -7910,7 +7900,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.27.0",
+      "version": "6.28.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8580,9 +8570,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
The lockfile contains vulnerable transitive dependencies behind 12 open Dependabot alerts, including two high-severity alerts. Refresh the affected packages within their existing compatible ranges so clean installs use patched runtime and release-tool dependencies.

| Dependency | Locked update | Alerts addressed |
|---|---|---|
| js-yaml | 4.3.1 → 4.3.2 | #15 (high) |
| hono | 4.13.4 → 4.13.7 | #12, #13, #14 |
| qs | 6.15.3 → 6.16.0 | #10, #11 |
| npm | 11.19.0 → 11.19.1 | Bundled ip-address 10.2.0 → 10.5.0 addresses #7, #8, #9 (high); bundled undici 6.27.0 → 6.28.0 addresses #4, #5, #6 |

Only `package-lock.json` changes. npm also refreshes its bundled tar, brace-expansion and libnpmpack, and removes an already-extraneous conventional-commits-filter entry. No version overrides or audit exclusions are added, and the update does not raise the existing development-tool Node requirement.

Validation completed locally on macOS with Node 24.19.0/npm 11.17.0 and Node 22.23.2/npm 11.19.1:

- Clean `npm ci` succeeds without changing the lockfile.
- Build, lint, formatting, typecheck, and coverage checks pass on both Node versions.
- 160 tests across 7 files pass on each Node version, including integration and end-to-end tests. Coverage: 99.39% statements, 94.09% branches, 100% functions, 99.38% lines.
- Full and production-only npm audits report zero vulnerabilities.
- Every installed copy of each affected package was compared with the vulnerable ranges in all 12 current GitHub alerts; all are outside those ranges.

Tested base: `d3458aa37afcc6aff815f94b067e6a67f162454c`. Remote CI will validate the Linux/Windows/macOS matrix. This PR does not merge or release the package; alert closure depends on the change reaching the default branch and GitHub rescanning it.
